### PR TITLE
Libertine auch im Mathe-Modus.

### DIFF
--- a/skript.tex
+++ b/skript.tex
@@ -42,11 +42,11 @@
 %\setotherlanguage{german}
 
 % Do not change the order of usepackages in the following block; YOU HAVE BEEN WARNED!
-\makeatletter  
-	\let\saved@bibitem\@bibitem  
-\makeatother  
-\usepackage{bibentry}  
-\usepackage[hidelinks]{hyperref}  
+\makeatletter
+	\let\saved@bibitem\@bibitem
+\makeatother
+\usepackage{bibentry}
+\usepackage[hidelinks]{hyperref}
 \usepackage[ngerman]{cleveref}
 \Crefname{algocf}{Algorithmus}{Algorithmen}
 \crefname{algocf}{Alg.}{Algs.}
@@ -103,6 +103,8 @@
 
 \input{style}
 \input{defs}
+
+\usepackage[libertine]{newtxmath}  % after amsthm
 
 \title{Network Science und Algorithm Engineering}
 \author{Manuel Penschuck}


### PR DESCRIPTION
Die Schriftart Libertine wird nun auch für den Mathemodus verwendet. Ich konnte keine Veränderung der Zeilen, Seitenzahlen o. Ä. entdecken.

Anmerkung 1: Es wäre deutlich empfehlenswerter, das Paket `libertinus` zu laden, anstatt auf `libertine` und `newtxmath` zu setzen. `libertinus` lädt aber `unicode-math`, welches mit anderen geladenen Paketen kollidiert. Wäre es mein Dokument, behöbe ich ja die Fehler, aber so... ¯\\_(ツ)_/¯
Anmerkung 2: Ich empfehle wärmstens, `newtxmath` mit der Option `slantedGreek` zu laden. Die Optionen `libaltvw` und `liby` sind u. U. auch einen Blick wert.