### PR TITLE
Neues, eckiges Rad durch altes, rundes Rad ersetzt.

### DIFF
--- a/einleitung.tex
+++ b/einleitung.tex
@@ -11,17 +11,17 @@ In sozialen Netzen bilden sich z.B. lokal stark vernetzte Gruppen (Communities),
 Network Science versucht diese Eigenschaften zu finden und zu verstehen.
 Hierzu vereinigt es Methoden aus Mathematik, Informatik, und Physik.
 
-\vspace{-2em}
-\floatmarginfigure{
+\begin{marginfigure}
     \scalebox{0.9}{
         \begin{tikzpicture}[
-            box/.style={draw, minimum width=8em, minimum height=2.5em, inner sep=0.2em, align=center},
-            arr/.style={draw, >={LaTeX[width=1em,length=1em]}, thick, ->, labelcolor}
-            ]
-            \node[box] (s0) at (0,  0.0em) {Algorithmen-\\[-0.4em]entwurf};
-            \node[box] (s1) at (0, -4.5em) {Theoretische \\[-0.4em] Analyse};
+            box/.style={draw, minimum width=10em, minimum height=2.5em, inner sep=0.2em, align=center},
+            arr/.style={draw, >={LaTeX[width=1em,length=1em]}, thick, ->, labelcolor},
+            every node/.style={font=\marginfont},
+        ]
+            \node[box] (s0) at (0,  0.0em) {Algorithmenentwurf};
+            \node[box] (s1) at (0, -4.5em) {Theoretische Analyse};
             \node[box] (s2) at (0, -9.0em) {Implementierung};
-            \node[box] (s3) at (0,-13.5em) {Experimentelle \\[-0.4em] Analyse};
+            \node[box] (s3) at (0,-13.5em) {Experimentelle Analyse};
 
             \path[arr] (s0) to (s1);
             \path[arr] (s1) to (s2);
@@ -29,9 +29,12 @@ Hierzu vereinigt es Methoden aus Mathematik, Informatik, und Physik.
 
             \path[arr] (s3.east) to ++(1.5em,0) |- (s0);
             \path[arr] (s3.east) to ++(1.5em,0) |- (s2);
-        \end{tikzpicture}}
-    \caption{Algorithm Engineering Zyklus}
-    \label{fig:intro/algorithm-engineering}}
+        \end{tikzpicture}
+    }
+    \caption{Zyklus im Algorithm Engineering}
+    \label{fig:intro/algorithm-engineering}
+\end{marginfigure}
+
 Ziel des \emph{Algorithm Engineering} ist es die Spaltung zwischen Theorie und Praxis im Algorithmenentwurf zu überbrücken.
 Es geht also darum, theoretisch effiziente als auch praktisch schnelle und implementierbare Algorithmen zu entwickeln.
 Hierbei kommt oft die in \cref{fig:intro/algorithm-engineering} dargestellte zyklische Entwurfsmethode zum Einsatz:

--- a/grad_sequenzen.tex
+++ b/grad_sequenzen.tex
@@ -367,21 +367,6 @@ Bevor wir uns effiziente Generatoren für das Chung-Lu Modell ansehen, diskutier
 \subsection{Rejection Sampling}
 Im Folgenden verallgemeinern wird die sog. Verwerfungsmethode (rejection sampling), die wir bereits in einer sehr einfachen Ausprägung beim Ziehen ohne Zurücklegen und Generieren einfacher Graphen genutzt haben.
 Damals war die Kernidee jedes Mal etwa:
-\floatmarginfigure{
-    \begin{tikzpicture}
-        \node[draw, minimum width=4cm, minimum height=4cm] {};
-
-        \foreach \x in {-18, -16, ..., 18} {
-                \foreach \y in {-18, -16, ..., 18} {
-                        \node[circle, inner sep=0, minimum width=0.5mm, fill] at (\x mm, \y mm) {};
-                    }
-            }
-        \node[fill=blue, opacity=0.2, cloud, minimum width=3.8cm, minimum height=2.5cm] (c) at (0,0) {};
-        \node[draw, cloud, minimum width=3.8cm, minimum height=2.5cm] (c) at (0,0) {Ziel};
-    \end{tikzpicture}
-    \caption{Rejection Sampling für Uniforme Verteilung}
-    \label{fig:rejection-uniform}
-}
 Wir nutzen einen stochastischen Prozess, der uns Vorschläge unterbreitet (proposal distribution).
 Dieser Prozess hatte bereits die gewünschte Verteilung, lieferte aber u.\,U. Vorschläge, die wir kategorisch ablehnen mussten;
 beim $\Gnm$-Modell mussten wir bereits gezogene Kanten zurückweisen.
@@ -392,6 +377,24 @@ Nach dem Ablehnen unerwünschter Element erhielten wir dann die Zielverteilung (
 Die proposal distribution entspricht der uniformen Verteilung in der Box (visualisiert durch das reguläre Gitter).
 Die Zielverteilung ist ebenfalls uniform -- allerdings über einer eingeschränkten Grundgesamtheit.
 Das Gitter ist auch auf dieser uniform verteilt.
+
+\begin{marginfigure}
+    \begin{tikzpicture}[
+		every node/.style={font=\marginfont},
+    ]
+        \node[draw, minimum width=4cm, minimum height=4cm] {};
+
+        \foreach \x in {-18, -16, ..., 18} {
+            \foreach \y in {-18, -16, ..., 18} {
+                \node[circle, inner sep=0, minimum width=0.5mm, fill] at (\x mm, \y mm) {};
+            }
+        }
+        \node[fill=blue, opacity=0.2, cloud, minimum width=3.8cm, minimum height=2.5cm] (c) at (0,0) {};
+        \node[draw, cloud, minimum width=3.8cm, minimum height=2.5cm] (c) at (0,0) {Ziel};
+    \end{tikzpicture}
+    \caption{Rejection Sampling für uniforme Verteilung}
+    \label{fig:rejection-uniform}
+\end{marginfigure}
 
 Ein weiteres Beispiel ist ein normaler Spielwürfel mit sechs gleich wahrscheinlichen Seiten, die von $1$ bis $6$ beschriftet sind.
 Wir können mit diesem Würfel uniform aus \set{1,2,3,4,5} ziehen:

--- a/style.tex
+++ b/style.tex
@@ -59,7 +59,7 @@
 \sidecaptionvpos{table}{t}
 \renewcommand*\sidecaptionrelwidth{0.75}
 \captionsetup[table]{format=plain, font={color=sidecolor,small}}
-\DeclareCaptionStyle{marginfigure}{format=plain, labelfont={sf,color=labelcolor,small}, textfont={sl,sf,small}}
+\DeclareCaptionStyle{marginfigure}{format=plain, labelfont={sf,color=labelcolor}, textfont={sf}}
 \DeclareCaptionStyle{sidecaption}{format=plain, font={color=sidecolor, small}, labelfont={sf,color=labelcolor}, textfont={sl,sf}}
 \DeclareCaptionStyle{sidecapfmt}{format=plain, font={color=sidecolor, small}, labelfont={sf,color=labelcolor}, textfont={sl,sf}}
 
@@ -371,11 +371,4 @@ state?/.style={conflict}
 		}{
 		\resettocdepth
 	\end{subappendices}
-}
-
-\newcommand{\floatmarginfigure}[1]{
-	\begin{figure}[h]%
-		\aside{\ \par \vspace{-0.5em} #1}%
-		\vspace{-1.5em}
-	\end{figure}
 }


### PR DESCRIPTION
- Es gibt bereits die Umgebung `marginfigure`.
- Der Befehl `\floatmarginfigure` ist irreführend benannt, da das Bild seine Gleitfähigkeit verliert.
- `\floatmarginfigure` hat unglaubliche Probleme mit Abständen, die nur ungenügend behoben werden. `marginfigure` hat diese nicht.
- Es ist sowieso ein Stil für die Beschriftung von `marginfigure` vorhanden. Wieso also nicht nutzen?
  - Der Stil ward der normalen Beschriftung von Abbildungen angepasst, da dieser bisher eingesetzt wird.
     - Wahrscheinlich sollte man das auch für die Stile von `sidecaption` und `sidecapfmt` (wozu ist der?) machen.
- Durch die Einbindung in `\aside` hatten Knotenbeschriftungen zwangsweise den Schriftstil `marginnote` übernommen. Der wird nun händisch hinzugefügt – entfernen, falls unerwünscht!