### PR TITLE
Anpassung des Kapitels »1 Einleitung«.

### DIFF
--- a/einleitung.tex
+++ b/einleitung.tex
@@ -5,10 +5,10 @@ In dieser Veranstaltung möchten wir also nicht die Vereinigung beider Felder be
 Dennoch sollten wir grob die Felder charakterisieren.
 
 \emph{Network Science} beschäftigt sich mit der Analyse und Modellierung von komplexen Netzwerken.
-Beispiele sind soziale Netze, Kommunikations- und Verkehrsnetze, biologische Netzwerke und viele mehr.
-Sie zeichnen sich durch sogenanntes \emph{emergent Verhalten} aus: ohne dass einzelnen Knoten oder Kanten bewusst darauf hinarbeiten, entsteht ein komplexes Verhalten des Gesamtsystems.
-In sozialen Netzen bilden sich z.B. lokal stark vernetzte Gruppen (Communities), es gibt einige zentrale Teilnehmer, die übermäßig stark vernetzt sind (Celebrities), und Netze haben überraschend geringe Distanzen zwischen Nutzern.
-Network Science versucht diese Eigenschaften zu finden und zu verstehen.
+Beispiele sind soziale, Kommunikations- und Verkehrsnetze, biologische Netzwerke und viele mehr.
+Sie zeichnen sich durch sogenanntes \emph{emergentes Verhalten} aus: Ohne dass einzelnen Knoten oder Kanten bewusst darauf hinarbeiten, entsteht ein komplexes Verhalten des Gesamtsystems.
+In sozialen Netzen bilden sich z.\,B. lokal stark vernetzte Gruppen (Communities), es gibt einige zentrale Teilnehmer, die übermäßig stark vernetzt sind (Celebrities), und Netze haben überraschend geringe Distanzen zwischen Nutzern.
+Network Science versucht, diese Eigenschaften zu finden und zu verstehen.
 Hierzu vereinigt es Methoden aus Mathematik, Informatik, und Physik.
 
 \vspace{-2em}
@@ -32,13 +32,13 @@ Hierzu vereinigt es Methoden aus Mathematik, Informatik, und Physik.
         \end{tikzpicture}}
     \caption{Algorithm Engineering Zyklus}
     \label{fig:intro/algorithm-engineering}}
-Ziel des \emph{Algorithm Engineering} ist es die Spaltung zwischen Theorie und Praxis im Algorithmenentwurf zu überbrücken.
+Ziel des \emph{Algorithm Engineering} ist es, die Spaltung zwischen Theorie und Praxis im Algorithmenentwurf zu überbrücken.
 Es geht also darum, theoretisch effiziente als auch praktisch schnelle und implementierbare Algorithmen zu entwickeln.
 Hierbei kommt oft die in \cref{fig:intro/algorithm-engineering} dargestellte zyklische Entwurfsmethode zum Einsatz:
 
-Wir entwerfen meist zuerst einen Algorithmus und versuchen dessen Performance theoretisch vorherzusagen;
-diese Hypothesen werden dann experimentell überprüft und ---je nach Ergebnis--- der Algorithmus oder die Analyse (z.B. Average Case statt Worst Case) angepasst.
-Dieser Zyklus wird iterativ wiederholt, bis ein Algorithmus gefunden ist, der sowohl praktisch gut funktioniert und theoretisch verstanden ist.
+Wir entwerfen meist zuerst einen Algorithmus und versuchen, dessen Performance theoretisch vorherzusagen;
+diese Hypothesen werden dann experimentell überprüft und -- je nach Ergebnis -- der Algorithmus oder die Analyse (z.\,B. Average Case statt Worst Case) angepasst.
+Dieser Zyklus wird wiederholt, bis ein Algorithmus gefunden ist, der sowohl praktisch gut funktioniert als auch theoretisch verstanden ist.
 
 Um praktisch nützliche Vorhersagen treffen zu können, verwendet man im Algorithm Engineering möglichst realistische Modelle für die Maschine und die Eingabedaten.
 Zur Analyse von Graphalgorithmen benötigen wir also geeignete Modelle für Netzwerke.
@@ -48,21 +48,21 @@ So ergänzen sich die beiden Felder.
 \section{Über diese Veranstaltung}
 Lernziele dieser Veranstaltung beinhalten:
 \begin{itemize}
-    \item Wichtige Eigenschaften beobachteten Netzwerken (z.B. Dichte, Gradverteilung, Zusammenhang, Durchmesser, Lokales Clustering, Globales Clustering)
-    \item Methoden diese Eigenschaften nachzubilden und zu erklären
+    \item Wichtige Eigenschaften von beobachteten Netzwerken (z.\,B. Dichte, Gradverteilung, Zusammenhang, Durchmesser, lokales Clustering, globales Clustering)
+    \item Methoden, diese Eigenschaften nachzubilden und zu erklären
     \item Zufallsgraphen und ihre Eigenschaften
     \item Effiziente Algorithmen für und auf Zufallsgraphen
-    \item Effiziente randomisierte Algorithmen (wir betrachten viele Graphgeneratoren --- die Techniken eigenen sich aber viel allgemeiner für diverse Simulationsaufgaben)
+    \item Effiziente, randomisierte Algorithmen (wir betrachten viele Graphgeneratoren -- die Techniken eignen sich aber viel allgemeiner für diverse Simulationsaufgaben)
 \end{itemize}
 
 \section{Begrifflichkeiten}
-Ein \emph{Netzwerk} ist ein System in dem Personen/Agenten/Objekte (etc.) miteinander in Relation stehen (z.B. durch eine Freundschaft, ein Gespräch, usw.).
-\emph{Graphen} sind ein abstraktes Modell dieses Systems: wir identifizieren die Akteure mit den Knoten und die Beziehungen mit den Kanten.
+Ein \emph{Netzwerk} ist ein System, in dem Personen/Agenten/Objekte (etc.) miteinander in Relation stehen (z.\,B. durch eine Freundschaft, ein Gespräch usw.).
+\emph{Graphen} sind ein abstraktes Modell dieses Systems: Wir identifizieren die Akteure mit den Knoten und die Beziehungen mit den Kanten.
 Wenn wir ein Netzwerk aus der echten Welt in einen Graphen übersetzen, sprechen wir oft von einem \emph{beobachteten Netzwerk}.
 Diese Abbildung geht oft mit dem Verlust von Informationen einher (wir wollen für den Anwendungsfall Unwesentliches ausblenden) und ist oft nicht eindeutig.
 
 \begin{example}
-    Die akademische Arbeit ist von Kollaboration geprägt --- Wissenschaftler arbeiten zusammen und publizieren schließlich gemeinsam ihre Ergebnisse.
+    Die akademische Arbeit ist von Kollaboration geprägt -- Wissenschaftler arbeiten zusammen und publizieren schließlich gemeinsam ihre Ergebnisse.
     Es handelt sich also ganz klar um ein Netzwerk.
     Wie modellieren wir aber den zugrunde liegenden Graphen?
     Hier ein paar Ansätze:
@@ -78,10 +78,10 @@ Diese Abbildung geht oft mit dem Verlust von Informationen einher (wir wollen f�
 
         \item Wir können die Autoren \emph{und} Publikationen als Knoten auffassen und je eine Publikation mit allen Urhebern verbinden.
               Dieser Graph ist bipartit\footnote{Wir können jeden Hypergraph analog in einen bipartiten Graphen übersetzen.}, da weder Autoren noch Publikationen untereinander verbunden sind.
-              Kanten könnten jetzt sogar noch weitere Informationen tragen, z.B. um den Hauptautor anzuzeigen.\hfill \qedhere
+              Kanten könnten jetzt sogar noch weitere Informationen tragen, z.\,B. den Hauptautor.\qedhere
     \end{itemize}
 \end{example}
 
 \noindent
-Keines dieser Modelle ist \emph{richtig} oder \emph{falsch} --- die Wahl hängt davon ab, was wir mit dem Graphen bezwecken.
+Keines dieser Modelle ist \emph{richtig} oder \emph{falsch} -- die Wahl hängt davon ab, was wir mit dem Graphen bezwecken.
 


### PR DESCRIPTION
- Erster Satz in zweitem Absatze leicht verkürzt, um Quasi-Hurenkind zu verhindern.
- Letzter Satz in Aufzählung von Kapitel »1.2 Begrifflichkeiten« leicht verkürzt, um zu verhindern, dass das Dreieck in die nächste Zeile rutscht und so eine weitere Seite benötigt wird.
- Ich empfehle, eine Entscheidung bezüglich Zeilenumbrüchen und Gedankenstrichen zu treffen (also wohin das geschützte Leerzeichen gesetzt werden soll).
- Im Deutschen kommt vor das letze Element einer nicht vollständigen Aufzählung, also vor …, etc., usw. u. v. a. m., kein Komma (im Englischen schon).