### PR TITLE
Macros für deutsche Abkürzungen

### DIFF
--- a/defs.tex
+++ b/defs.tex
@@ -212,6 +212,18 @@
 \def\ie        {\hcs{i.e.,}}
 \def\citeneeded{\textsuperscript{\textcolor{red}{[cite needed]}}}
 
+% Deutsche Abkürzungen
+\def\zB   	{\hcs{z.\,B.}}
+\def\ZB     {\hcs{Z.\,B.}}
+\def\dh		{\hcs{d.\,h.}}
+\def\Dh 	{\hcs{D.\,h.}}
+\def\idR 	{\hcs{i.\,d.\,R.}}
+\def\IdR 	{\hcs{I.\,d.\,R.}}
+\def\oBdA 	{\hcs{o.\,B.\,d.\,A.}}
+\def\OBdA 	{\hcs{O.\,B.\,d.\,A.}}
+\def\oA 	{\hcs{o.\,Ä.}}
+\def\sd 	{\hcs{s.\,d.}}
+
 \newcommand{\Ex}[1]{\hcm{\mathbb E\left[#1\right]}}
 \newcommand{\Prob}[1]{\hcm{\mathbb P\left[#1\right]}}
 

--- a/einleitung.tex
+++ b/einleitung.tex
@@ -7,7 +7,7 @@ Dennoch sollten wir grob die Felder charakterisieren.
 \emph{Network Science} beschäftigt sich mit der Analyse und Modellierung von komplexen Netzwerken.
 Beispiele sind soziale, Kommunikations- und Verkehrsnetze, biologische Netzwerke und viele mehr.
 Sie zeichnen sich durch sogenanntes \emph{emergentes Verhalten} aus: Ohne dass einzelnen Knoten oder Kanten bewusst darauf hinarbeiten, entsteht ein komplexes Verhalten des Gesamtsystems.
-In sozialen Netzen bilden sich z.\,B. lokal stark vernetzte Gruppen (Communities), es gibt einige zentrale Teilnehmer, die übermäßig stark vernetzt sind (Celebrities), und Netze haben überraschend geringe Distanzen zwischen Nutzern.
+In sozialen Netzen bilden sich \zB lokal stark vernetzte Gruppen (Communities), es gibt einige zentrale Teilnehmer, die übermäßig stark vernetzt sind (Celebrities), und Netze haben überraschend geringe Distanzen zwischen Nutzern.
 Network Science versucht, diese Eigenschaften zu finden und zu verstehen.
 Hierzu vereinigt es Methoden aus Mathematik, Informatik, und Physik.
 
@@ -37,7 +37,7 @@ Es geht also darum, theoretisch effiziente als auch praktisch schnelle und imple
 Hierbei kommt oft die in \cref{fig:intro/algorithm-engineering} dargestellte zyklische Entwurfsmethode zum Einsatz:
 
 Wir entwerfen meist zuerst einen Algorithmus und versuchen, dessen Performance theoretisch vorherzusagen;
-diese Hypothesen werden dann experimentell überprüft und -- je nach Ergebnis -- der Algorithmus oder die Analyse (z.\,B. Average Case statt Worst Case) angepasst.
+diese Hypothesen werden dann experimentell überprüft und -- je nach Ergebnis -- der Algorithmus oder die Analyse (\zB Average Case statt Worst Case) angepasst.
 Dieser Zyklus wird wiederholt, bis ein Algorithmus gefunden ist, der sowohl praktisch gut funktioniert als auch theoretisch verstanden ist.
 
 Um praktisch nützliche Vorhersagen treffen zu können, verwendet man im Algorithm Engineering möglichst realistische Modelle für die Maschine und die Eingabedaten.
@@ -48,7 +48,7 @@ So ergänzen sich die beiden Felder.
 \section{Über diese Veranstaltung}
 Lernziele dieser Veranstaltung beinhalten:
 \begin{itemize}
-    \item Wichtige Eigenschaften von beobachteten Netzwerken (z.\,B. Dichte, Gradverteilung, Zusammenhang, Durchmesser, lokales Clustering, globales Clustering)
+    \item Wichtige Eigenschaften von beobachteten Netzwerken (\zB Dichte, Gradverteilung, Zusammenhang, Durchmesser, lokales Clustering, globales Clustering)
     \item Methoden, diese Eigenschaften nachzubilden und zu erklären
     \item Zufallsgraphen und ihre Eigenschaften
     \item Effiziente Algorithmen für und auf Zufallsgraphen
@@ -56,7 +56,7 @@ Lernziele dieser Veranstaltung beinhalten:
 \end{itemize}
 
 \section{Begrifflichkeiten}
-Ein \emph{Netzwerk} ist ein System, in dem Personen/Agenten/Objekte (etc.) miteinander in Relation stehen (z.\,B. durch eine Freundschaft, ein Gespräch usw.).
+Ein \emph{Netzwerk} ist ein System, in dem Personen/Agenten/Objekte (etc.) miteinander in Relation stehen (\zB durch eine Freundschaft, ein Gespräch usw.).
 \emph{Graphen} sind ein abstraktes Modell dieses Systems: Wir identifizieren die Akteure mit den Knoten und die Beziehungen mit den Kanten.
 Wenn wir ein Netzwerk aus der echten Welt in einen Graphen übersetzen, sprechen wir oft von einem \emph{beobachteten Netzwerk}.
 Diese Abbildung geht oft mit dem Verlust von Informationen einher (wir wollen für den Anwendungsfall Unwesentliches ausblenden) und ist oft nicht eindeutig.
@@ -78,7 +78,7 @@ Diese Abbildung geht oft mit dem Verlust von Informationen einher (wir wollen f�
 
         \item Wir können die Autoren \emph{und} Publikationen als Knoten auffassen und je eine Publikation mit allen Urhebern verbinden.
               Dieser Graph ist bipartit\footnote{Wir können jeden Hypergraph analog in einen bipartiten Graphen übersetzen.}, da weder Autoren noch Publikationen untereinander verbunden sind.
-              Kanten könnten jetzt sogar noch weitere Informationen tragen, z.\,B. den Hauptautor.\qedhere
+              Kanten könnten jetzt sogar noch weitere Informationen tragen, \zB den Hauptautor.\qedhere
     \end{itemize}
 \end{example}
 

--- a/erdos_renyi.tex
+++ b/erdos_renyi.tex
@@ -4,7 +4,7 @@ Der Zufallsgraph beschreibt also ein Ensemble von Graphen, das so entworfen sein
 Solche maßgeschneiderte Zufallsgraphen werden oft als \emph{Netzwerkmodell} bezeichnet.
 
 Das Forschungsfeld der Zufallsgraphen nahm mit den Arbeiten von Gilbert~\cite{gilbert_1959}, sowie Erd\H{o}s und R\'enyi~\cite{erdos_renyi_1960} Anfang der 1960er Jahre an Fahrt auf.
-Die beiden Arbeiten definieren Zufallsgraphen, die zunächst für abstrakte Untersuchungen (z.\,B. die probabilistische Methode) verwendet wurden.
+Die beiden Arbeiten definieren Zufallsgraphen, die zunächst für abstrakte Untersuchungen (\zB die probabilistische Methode) verwendet wurden.
 Der Fokus auf die Modellierung von beobachteten Netzwerken kam erst später hinzu.
 Dennoch spielen die Modelle in der Netzwerkforschung bis heute eine wichtige Rolle.
 Wir werden sie daher bald genauer betrachten, fangen jedoch mit einem noch einfacheren Modell an.
@@ -37,9 +37,9 @@ Analog sieht es für die $\binom n 2$ möglichen Kanten in einem ungerichteten G
 
 Beachte aber auch, dass formal \cref{eq:gerichtet_gn} und \cref{eq:gleichverteilt_gerichtet_gn} widersprüchlich scheinen.
 In \cref{eq:gerichtet_gn} fordern wir nur, dass die Knotenmenge~$V$ die Kardinalität $|V| = n$ hat.
-Offensichtlich gibt es unbeschränkt viele dieser Wahlen; für $n=3$ z.\,B. $\set{1,2,3}$, $\set{2,3,4}$, \ldots, $\set{k, k+1, k+2}$ für alle $k \in \mathbb N$.
+Offensichtlich gibt es unbeschränkt viele dieser Wahlen; für $n=3$ \zB $\set{1,2,3}$, $\set{2,3,4}$, \ldots, $\set{k, k+1, k+2}$ für alle $k \in \mathbb N$.
 Die Wahl der Knotenbezeichner hat jedoch keinen Einfluss auf die Netzwerkeigenschaften.
-Daher werden wir in dieser Veranstaltung grundsätzlich annehmen, dass die Knotenmengen in irgendeiner Form fixiert sind, z.\,B. als $V = \set{1, \ldots, n} = [n]$ oder $V = \set{v_1, \ldots, v_n}$.
+Daher werden wir in dieser Veranstaltung grundsätzlich annehmen, dass die Knotenmengen in irgendeiner Form fixiert sind, \zB als $V = \set{1, \ldots, n} = [n]$ oder $V = \set{v_1, \ldots, v_n}$.
 
 \bigskip
 
@@ -70,7 +70,7 @@ intuitiv hat \glqq jeder zweite Graph\grqq{} mindestens die Hälfte aller mögli
 \begin{proof}
     Im Folgenden betrachten wir nur gerichtete Graphen; der Beweis läuft analog für ungerichtete Graphen.
     Stellen wir uns einen beliebigen Graphen~$G = (V, E)$ vor.
-    Dann sei $\bar G = (V, \bar E)$ sein Komplement, d.\,h. für alle möglichen Kanten gilt:
+    Dann sei $\bar G = (V, \bar E)$ sein Komplement, \dh für alle möglichen Kanten gilt:
     \begin{equation}
         \forall e \in V\times V\colon \quad\quad e \in \bar E \Leftrightarrow e \notin E
     \end{equation}
@@ -115,7 +115,7 @@ Dies ist offensichtlich deutlich mehr als in planaren Graphen möglich wäre.
 Ganz ähnlich sieht es mit anderen sozialen Netzen aus: Ein durchschnittlicher Erwachsener kennt deutlich mehr als sechs andere Menschen persönlich (oft werden Zahlen zwischen 100 und 300 genannt).
 
 \subsection{Die meisten Netzwerke sind dünn}
-In \cref{fig:kantenanzahl} hat nur ein verschwindend geringer Anteil der Netzwerke mindestens die Hälfte aller Kanten (d.\,h. ist oberhalb der roten Linie).
+In \cref{fig:kantenanzahl} hat nur ein verschwindend geringer Anteil der Netzwerke mindestens die Hälfte aller Kanten (\dh ist oberhalb der roten Linie).
 Wie erklärt sich das?
 In der Regel verursacht eine Kante Kosten:
 Eine Straße muss gebaut werden, eine Freundschaft muss aufrecht erhalten werden (Zeitinvestment), eine Nachricht muss geschrieben werden etc.
@@ -138,7 +138,7 @@ Wir benötigen also Prozesse, die weniger dichte Graphen erzeugen können --
 am besten parametrisiert, damit wir unterschiedlichen Netzwerktypen Rechnung tragen können.
 Im Folgenden betrachten wir zwei solcher Modelle.
 
-Das \Gnm-Modell \aside{Erd\H{o}s-R\'enyi Graphen \Gnm} von P.~Erd\H{o}s und A.~R\'enyi beschreibt die Gleichverteilung über allgemeinen Graphen mit $n$ Knoten und $m$ Kanten, d.\,h. wir betrachten die Grundmenge
+Das \Gnm-Modell \aside{Erd\H{o}s-R\'enyi Graphen \Gnm} von P.~Erd\H{o}s und A.~R\'enyi beschreibt die Gleichverteilung über allgemeinen Graphen mit $n$ Knoten und $m$ Kanten, \dh wir betrachten die Grundmenge
 \begin{equation}
     \gGnm = \twoset{G}{G=(V,E) \in \mathbb G(n) \textnormal{ und } |E| = m}.
 \end{equation}
@@ -259,7 +259,7 @@ Da uns die Binomialverteilung regelmäßig begegnen wird, wollen wir uns diese k
 
 Die Standardabweichung $\sigma = \sqrt{\varv{B_{N,p}}} \le \sqrt{\expv{B_{N,p}}}$ ist also relativ klein.
 Wir können daher davon ausgehen, dass für hinreichend großes $N$ die Binomialverteilung recht stark um ihren Erwartungswert $Np$ konzentriert ist.
-Daher sagen wir, dass \Gnm und \Gnp mit $p=m/n^2$ asymptotisch (d.\,h. für $n \to \infty$) äquivalent sind.
+Daher sagen wir, dass \Gnm und \Gnp mit $p=m/n^2$ asymptotisch (\dh für $n \to \infty$) äquivalent sind.
 Häufig ist es jedoch einfacher \Gnp-Graphen zu analysieren, da -- im Gegensatz zu \Gnm-Graphen -- alle Kanten unabhängig gezogen werden.
 
 \section{Effizientes Ziehen von \Gnp-Graphen}
@@ -268,9 +268,9 @@ Nehmen wir etwa an, dass wir einen Algorithmus implementiert haben und dessen Ge
 Dann können Zufallsgraphen unter anderem aus folgenden Gründen nützlich sein:
 \begin{itemize}
     \item Wenn die Generatorsoftware vorhanden ist, können wir synthetische Instanzen in quasi unbeschränkter Menge generieren.
-    \item Parametrisierte Generatoren erlauben, den Einfluss gewisser Eigenschaften detailliert zu analysieren, z.\,B. Skalierungsexperimente.
-    \item Beobachtete Graphen haben oft \glqq Rauschen\grqq, d.\,h. nicht verstandene oder insignifikante Strukturen, die Messungen verfälschen können.
-          Zufallsgraphen hingegen haben i.\,d.\,R. eine gut verstandene Struktur, die es uns oft ermöglicht, vor dem Testen Hypothesen aufzustellen.
+    \item Parametrisierte Generatoren erlauben, den Einfluss gewisser Eigenschaften detailliert zu analysieren, \zB Skalierungsexperimente.
+    \item Beobachtete Graphen haben oft \glqq Rauschen\grqq, \dh nicht verstandene oder insignifikante Strukturen, die Messungen verfälschen können.
+          Zufallsgraphen hingegen haben \idR eine gut verstandene Struktur, die es uns oft ermöglicht, vor dem Testen Hypothesen aufzustellen.
     \item Einige Generatoren können anhand eines fixierten Startzustands (Random-Seed) dieselben Graphen wiederholt erzeugen.
           Wir müssen also die Eingaben nicht speichern/transferieren und können dennoch reproduzierbare Experimente durchführen.
 \end{itemize}
@@ -434,10 +434,10 @@ Betrachten wir konkret die ersten drei Werte der Funktionen:
 \end{center}
 \vspace{1em}
 
-Ein Generator sollte also z.\,B. den Wert $0$ mit Wahrscheinlichkeit 20\,\% ausgeben.
+Ein Generator sollte also \zB den Wert $0$ mit Wahrscheinlichkeit 20\,\% ausgeben.
 Da wir einen deterministischen Algorithmus konstruieren möchten, brauchen wir eine Quelle für den Zufall:
 Wir erwarten eine uniforme Zufallsvariable $U \in [0, 1)$ als Eingabe.
-Wir können also z.B. prüfen:
+Wir können also \zB prüfen:
 \begin{itemize}
     \item Wenn $U < 0.2$ ist, dann gebe den Wert $0$ zurück.
           Da $U$ uniform verteilt ist, ist die Wahrscheinlichkeit für $U < 0.2$ genau $0.2$.
@@ -491,7 +491,7 @@ Die Methode lässt sich aber auch auf andere $\Omega$ (inklusive kontinuierliche
 \end{figure}
 
 Zurück \aside{Inversionsmethode für geometrische Verteilungen} zur geometrischen Verteilung mit $f(\ell) = (1-p)^\ell p$.
-O.\,b.\,d.\,A. sei $0 < p < 1$, da $X$ sonst eine Konstante ist.
+\OBdA sei $0 < p < 1$, da $X$ sonst eine Konstante ist.
 Die kumulative Verteilungsfunktion lautet
 \begin{equation}
     F(\ell)
@@ -535,8 +535,8 @@ Ziehe uniform ohne Zurücklegen $k$ Elemente aus einer Menge $S = \set{s_1, \ldo
 \subsection{Reservoir Sampling}
 Reservoir Sampling ist eine allgemeine Technik, die es uns erlaubt $k$ Elemente aus einem Datenstrom zu ziehen.
 Hierbei müssen wir anfangs \emph{nicht} wissen, wie viele Elemente insgesamt im Strom sind.\footnote{
-    Ein praktischer Anwendungsfall sind z.B. Iteratoren oder Generatoren, die in vielen Programmiersprachen genutzt werden.
-    In Rust ist z.B. \texttt{rand::IteratorRandom::choose\_multiple} mittels Reservoir Sampling implementiert.
+    Ein praktischer Anwendungsfall sind \zB Iteratoren oder Generatoren, die in vielen Programmiersprachen genutzt werden.
+    In Rust ist \zB \texttt{rand::IteratorRandom::choose\_multiple} mittels Reservoir Sampling implementiert.
 }
 Im konkreten Fall besteht der Datenstrom also aus allen $s_i$ in beliebiger Reihenfolge.
 Vereinfachend können wir also annehmen, dass der Strom mindestens $k$ Elemente enthält.
@@ -580,7 +580,7 @@ In \cref{thm:reservoir-sampling} zeigen wir die Korrektheit von \cref{algo:reser
 \begin{proof}
     Sei $N$ die Länge des Stroms (ist dem Algorithmus nicht bekannt).
     Seien zudem $s_1, \ldots, s_N$ die Elemente in der Reihenfolge, in der sie aus dem Strom gelesen werden;
-    oBdA gelte $s_i = s_j \ \Leftrightarrow\ i = j$ (d.h. alle Elemente sind unterschiedlich; falls nicht, können wir die Tupel $(s_i, i)$ betrachten).
+    \oBdA gelte $s_i = s_j \ \Leftrightarrow\ i = j$ (\dh alle Elemente sind unterschiedlich; falls nicht, können wir die Tupel $(s_i, i)$ betrachten).
 
     Sei $R$ die Zufallsvariable, welche die Ausgabe des Algorithmus modelliert.
     Dann ist zu zeigen, dass $\prob{R = s_i} = 1 / N$ für alle $1 \le i \le N$.
@@ -636,7 +636,7 @@ Wir messen die Geschwindigkeit des Algorithmus zunächst nur indirekt, indem wir
 \begin{proof}
     Der Algorithmus baut $R$ inkrementell auf: wir beginnen mit $|R| = 0$ und fügen dann schrittweise je ein Element hinzu.
     Sei $X$ eine Zufallsvariable, die beschriebt, wie viele Iterationen der Algorithmus benötigt um $R$ zu erzeugen.
-    Ferner seien $X_1, \ldots, X_k$ Zufallsvariablen, wobei $X_i$ beschriebt, wie viele Versuche benötigt werden um das $i$-te Elemente zu finden (d.h. um $R$ von $|R| = i - 1$ auf  $|R| = i$ zu heben).
+    Ferner seien $X_1, \ldots, X_k$ Zufallsvariablen, wobei $X_i$ beschriebt, wie viele Versuche benötigt werden um das $i$-te Elemente zu finden (\dh um $R$ von $|R| = i - 1$ auf  $|R| = i$ zu heben).
     Per Konstruktion gilt $X = \sum_{i=1}^k X_i$ und aufgrund der Linearität des Erwartungswertes folgt
 
     \begin{equation}
@@ -644,7 +644,7 @@ Wir messen die Geschwindigkeit des Algorithmus zunächst nur indirekt, indem wir
     \end{equation}
 
     Wir können also zunächst die Erwartungswerte $\expv{X_i}$ isoliert betrachten.
-    Unmittelbar bevor wir das $i$-te Element ziehen, haben wir $i-1$ Elemente bereits bestimmt, d.h. $|R| = i - 1$.
+    Unmittelbar bevor wir das $i$-te Element ziehen, haben wir $i-1$ Elemente bereits bestimmt, \dh $|R| = i - 1$.
     Mit Wahrscheinlichkeit $q_i = (i-1) / N$ erwischen wir also ein bereits gezogenes Element und versuchen es erneut.
     Mit Wahrscheinlichkeit $p_i = 1 - q_i = (N - (i - 1)) / N$ ziehen wir aber ein Element, dass noch nicht Teil von $R$ ist.
     Es gilt also
@@ -731,7 +731,7 @@ In der Regel ist der Parameter aus dem Kontext klar und wird daher in der Litera
     Wir verwenden dieselbe Modellierung wie im Beweis von \cref{lemma:basis-ziehen-ohne-zuruecklegen-versuche}:
     Sei $X = \sum_{i=1}^k X_i$ die Gesamtanzahl an Iterationen und $X_i - 1$ geometrisch verteilt mit Erfolgswahrscheinlichkeit~$p_i$.
 
-    Da $k \le N/2$, ziehen wir zu jedem Zeitpunkt mindestens mit Wahrscheinlichkeit $1/2$ ein neues Element, d.h. $p_i \ge 1/2$ für alle $i \ge 1$.
+    Da $k \le N/2$, ziehen wir zu jedem Zeitpunkt mindestens mit Wahrscheinlichkeit $1/2$ ein neues Element, \dh $p_i \ge 1/2$ für alle $i \ge 1$.
     Um die harmonische Reihe zu vermeiden, nutzen wir eine schlechtere Abschätzung, bei der wir alle $p_i = 1/2$ auf den minimalen Erfolgswert setzen.
     Sei $X' = \sum_{i=1}^k X'_i$ diese Verteilung und $X'_i - 1$ geometrisch mit Erfolgswahrscheinlichkeit $1/2$.
 
@@ -779,7 +779,7 @@ In der Regel ist der Parameter aus dem Kontext klar und wird daher in der Litera
 Welche Datenstruktur benötigen wir für $R$? Sie sollte Existenzanfragen ($x \in R$?) und Einfügen ($R \gets R \cup \set{x}$) effizient durchführen können.
 Ein Hashset unterstützt beide Operationen in erwartet konstanter Zeit, wodurch sich eine erwartete Laufzeit von $\Oh{k}$ ergibt; dies ist optimal in Erwartung.
 
-Für praktische Implementierungen kann es sich jedoch auch lohnen, das Hashset durch ein Bitset (d.h. ein Array in dem jeder Eintrag genau ein Bit groß ist) zu ersetzen.
+Für praktische Implementierungen kann es sich jedoch auch lohnen, das Hashset durch ein Bitset (\dh ein Array in dem jeder Eintrag genau ein Bit groß ist) zu ersetzen.
 Auf dem Papier benötigt ein Bitset $\Theta(N)$ viele Bits und ist somit in der Initialisierung teuer.
 In der Praxis benötigt aber jeder Eintrag in einem Hashset mindestens 64 Bit, sodass ein Bitset bereits für $N / k > 64$ weniger Platz benötigt (das trifft etwa auf 30\,\% der Netzwerke in \cref{fig:kantenanzahl} zu).
 Zusätzlich sind Existenzanfragen und Einfügeoperationen extrem schnell, wodurch ein Bitset oft einen lohnenswerten Kompromiss zwischen mehr Speicher für schnellere Ausführung darstellen kann.
@@ -814,7 +814,7 @@ Unsere Analysen sagen jedoch eine konstante Laufzeit pro gezogenem Element für 
 
 Wir sind also im Algorithm-Engineering-Zyklus auf eine Diskrepanz zwischen Theorie und Praxis gestoßen!
 Ist unsere Analyse falsch? Jaein.
-In der Bestimmung der Laufzeit nutzen wir eine Unit-Cost Random-Access-Machine (d.h. wir gingen davon aus, dass jede Operation gleich viel Zeit benötigt).
+In der Bestimmung der Laufzeit nutzen wir eine Unit-Cost Random-Access-Machine (\dh wir gingen davon aus, dass jede Operation gleich viel Zeit benötigt).
 Moderne Computer verfügen jedoch über ausgeklügelte Techniken, die gewisse Aspekte besonders beschleunigen.
 
 Hierzu gehören die sog. Speicherhierarchien: Ein Prozessor kann nur auf Daten operieren, die sich auf dem physischen Chip befinden, genauer in den Registern.
@@ -865,7 +865,7 @@ Betrachten wir das parallele Summieren $\sum_{i=1}^n x_n$ von Zahlen $X = (x_1, 
 
 In \cref{algo:parallel_sum} teilen wir die Eingabe rekursiv in zwei gleich große Teile (modulo Rundung) und berechnen die Teilsummen für beide rekursiv.
 Sobald die Teilergebnisse vorliegen, summieren wir diese in $\Oh{1}$ Zeit und geben es als Gesamtergebnis zurück.
-Dieses Schema funktioniert analog für alle assoziativen Operationen (z.B. Produkt, Min, Max).
+Dieses Schema funktioniert analog für alle assoziativen Operationen (\zB Produkt, Min, Max).
 
 In der Praxis findet man einige Software-Bibliotheken, die Fork-Join-Parallelismus zur Verfügung stellen;
 für C++ etwa \texttt{Cilk} oder Intels \texttt{oneTBB}, für Rust \texttt{rayon}.
@@ -895,7 +895,7 @@ Wir messen die Güte eines Fork-Join-Algorithmus mit zwei Eigenschaften:
           Der \aside{arbeits-optimal} Algorithmus leistet also asymptotisch nicht mehr Arbeit als die Laufzeit der besten sequentiellen Lösung; wir sagen er ist \emph{arbeits-optimal}.
 
     \item
-          Der \aside{Span / Parallel Depth} Span (engl. span oder parallel depth) misst die Anzahl der Instruktionen auf einem kritischen Pfad (d.h. eine längste Folge abhängiger Schritte).
+          Der \aside{Span / Parallel Depth} Span (engl. span oder parallel depth) misst die Anzahl der Instruktionen auf einem kritischen Pfad (\dh eine längste Folge abhängiger Schritte).
           Dies entspricht der Laufzeit, wenn wir unbeschränkt viele Prozessoren zur Verfügung haben.
           In \cref{algo:parallel_sum} müssen wir also analysieren, wie viele Instruktionen vor und nach dem Fork/Join Paar erforderlich sind und wie tief die Rekursion läuft:
           \begin{equation}
@@ -904,7 +904,7 @@ Wir messen die Güte eines Fork-Join-Algorithmus mit zwei Eigenschaften:
 \end{enumerate}
 
 Wenn wir ausreichend Prozessoren zur Verfügung haben, können wir also $n$ Zahlen in Zeit $\Oh{\log n}$ summieren.
-Zu ähnlichen Ergebnissen kommt man auch in anderen parallelen Maschinenmodellen (z.B. P-Rams).
+Zu ähnlichen Ergebnissen kommt man auch in anderen parallelen Maschinenmodellen (\zB P-Rams).
 
 \subsection{Rekursives Ziehen}
 In \cref{algo:parallel_sum} haben wir bereits ein gutes Grundgerüst für parallele Algorithmen gesehen:
@@ -914,7 +914,7 @@ Bezogen auf unser Problem, $k$~Stichproben aus $N$~Elementen zu ziehen, haben wi
     \item Teile $S$ deterministisch in $S_1$ und $S_2$: Wir können das Universum~$S$ mit $|S| = N$ in zwei Hälften $S_1$ und $S_2$ partitionieren mit $|S_1| = \lfloor N / 2 \rfloor$.
           Dann stellt sich die Frage: was ist die Anzahl~$k_1$ der Samples aus $S_1$, bzw. $k_2$ aus $S_2$. Klar ist nur $k_1 + k_2 = k$.
 
-    \item Teile $k$ deterministisch in $k_1$ und $k_2$: Wir können die Stichproben teilen, d.h. $k_1 = \lfloor k/n \rfloor$ wählen; dann müssen wir jedoch eine unbekannte Partitionierung von $S$ finden.
+    \item Teile $k$ deterministisch in $k_1$ und $k_2$: Wir können die Stichproben teilen, \dh $k_1 = \lfloor k/n \rfloor$ wählen; dann müssen wir jedoch eine unbekannte Partitionierung von $S$ finden.
 \end{enumerate}
 
 Auf den ersten Blick wirkt die zweite Variante zielführender.
@@ -964,7 +964,7 @@ Tatsächlich liefert aber die erste Variante einfachere Algorithmen, die auch ke
 Wie in \cref{fig:rekursive_k_aus_N}, teilen wir also das Universum~$S$ in zwei gleich große Hälften $S_1$ und $S_2$.
 Angenommen, wir täten dies nicht, wie viele Stichproben $k_1$ würde ein anderer Algorithmus aus $S_1$ ziehen?
 Wir wissen es nicht genau, da $k_1$ eine Zufallsvariable ist --- sie ist Hypergeometrisch verteilt:
-aus einer Gesamtpopulation von $N$ mit $k$~Treffern (d.h. die Elemente, die ein anderer Algorithmus gezogen hätte), ziehen wir $N_1$ Stichproben und erhalten $k_1$~Treffer.
+aus einer Gesamtpopulation von $N$ mit $k$~Treffern (\dh die Elemente, die ein anderer Algorithmus gezogen hätte), ziehen wir $N_1$ Stichproben und erhalten $k_1$~Treffer.
 In Erwartung sind es also $\expv{k_1} = k |S_1| / |S|$.
 
 Analog zu den zufälligen Sprüngen in \cref{subsec:gnp_zufaellige_spruenge}, ziehen wir $k_1$ aus einer Hypergeometrisch Verteilung.
@@ -1014,7 +1014,7 @@ Um die Performance von \cref{algo:parallel_k_aus_N} zu analysieren, treffen wir 
 
     \item Die Operationen $R_1 \cup R_2$ läuft in konstanter Zeit.
           Das ist realistisch: da die Elemente in der Menge $S$ paarweise verschieden sind, wissen wir, dass $|R_1 \cup R_2| = |R_1| + |R_2| = k$.
-          Es ist also kein Test auf Duplikate o.Ä. notwendig und es reicht aus $R_1$ und $R_2$ zu konkatenieren.
+          Es ist also kein Test auf Duplikate \oA notwendig und es reicht aus $R_1$ und $R_2$ zu konkatenieren.
           Das ist mit verketten Listen (inkl. Endpointer) in $\Oh{1}$ Zeit möglich.
 \end{enumerate}
 
@@ -1056,7 +1056,7 @@ Der Hybridalgorithmus in \cref{fig:benchmark_gnm_recursive_scale} nutzt, für gr
 Für kleine Teilprobleme mit $N < 10\,000$ kommt  ---je nach Dichte $k/N$--- entweder BitSet oder HashSet zum Einsatz.
 
 \section{Phasenübergänge in \Gnp und \Gnm}
-Die ersten analytischen Ergebnisse von Zufallsgraphen betrafen das Verhalten von kombinatorischen Eigenschaften für verschiedene Dichten (d.h. $m/n$ bei $\Gnm$, bzw $p$ bei $\Gnp$) im Grenzwert für $n \to \infty$.
+Die ersten analytischen Ergebnisse von Zufallsgraphen betrafen das Verhalten von kombinatorischen Eigenschaften für verschiedene Dichten (\dh $m/n$ bei $\Gnm$, bzw $p$ bei $\Gnp$) im Grenzwert für $n \to \infty$.
 In \aside{Wir nutzen ungerichtete Graphen und setzen $N = \binom n 2$} diesem Kapitel werden wir uns auf ungerichtete Graphen konzentrieren.
 
 Betrachten wir zunächst \Gnm Graphen.
@@ -1070,7 +1070,7 @@ Wir wollen uns an dieser Aussage ansehen, wie man die Wahrscheinlichkeit eines s
 
 \begin{proof}
     Sei $p(n,m)$ die Wahrscheinlichkeit, dass keine zwei Kanten einen gemeinsamen Endpunkt haben.
-    Wir vergleichen nun die Anzahl der möglichen Graphen mit der Anzahl der günstigen Graphen (d.h. ohne zwei Pfade).
+    Wir vergleichen nun die Anzahl der möglichen Graphen mit der Anzahl der günstigen Graphen (\dh ohne zwei Pfade).
     Zunächst beobachten wir, dass es $|\mathbb G(n,m)| = \binom N m = \binom{\binom n 2}{m}$ verschiedene $\Gnm$ Graphen gibt.
     Wie viele von diesen haben keine Knoten mit mindestens Kanten?
 
@@ -1122,7 +1122,7 @@ Wir wollen uns an dieser Aussage ansehen, wie man die Wahrscheinlichkeit eines s
 \end{proof}
 
 Beobachte, dass \cref{eq:wkeit_keine_zwei_kanten} eine exakte Wahrscheinlichkeit ist, die wir erst im Nachgang von unten abschätzen.
-Durch eine geeignete obere Schranke lässt sich zeigen, dass für $m \ge c \sqrt n$ für ein konstantes $c > 0$ (d.h. nicht von $n$ abhängig) die Wahrscheinlichkeit mindestens eines Knotens mit mindestens zwei Nachbarn gegen $1$ geht.
+Durch eine geeignete obere Schranke lässt sich zeigen, dass für $m \ge c \sqrt n$ für ein konstantes $c > 0$ (\dh nicht von $n$ abhängig) die Wahrscheinlichkeit mindestens eines Knotens mit mindestens zwei Nachbarn gegen $1$ geht.
 Wir sagen daher, dass \Gnm Graphen einen Phasenübergang mit Schwellwertfunktion $m(n) = \sqrt n$ haben.
 
 
@@ -1177,9 +1177,9 @@ Solange dies noch nicht der Fall ist, wird einer der folgenden Schritte ausführ
 \end{enumerate}
 
 Um Uneindeutigkeiten zu vermeiden, fixieren wir die Knotenordnung.
-Hierzu nehmen wir oBdA an, dass $V = \set{1, \ldots, n}$ natürliche Zahlen sind.
+Hierzu nehmen wir \oBdA an, dass $V = \set{1, \ldots, n}$ natürliche Zahlen sind.
 Die Mengen $V$ und $U$ seien aufsteigend geordnet, insbesondere werden immer die kleinsten passenden Elemente entnommen (in Schritten 1a und 2).
-Weiter, sei $S$ ein Stack, d.h. das Element, das als letztes eingefügt wurde, wird als erstes entfernt.
+Weiter, sei $S$ ein Stack, \dh das Element, das als letztes eingefügt wurde, wird als erstes entfernt.
 
 Das Besondere an unser DFS ist, dass wir keine Kantenliste als Eingabe bekommen, sondern uns vorstellen, einen Strom von unabhängig zufälligen Bits $X_1, \ldots, X_N$ zu erhalten, wobei $\prob{X_i = 1} = p$.
 Wenn wir nun in Schritt 1a einen Nachbar von $v$ suchen, iterieren wir gleichzeitig über $U$ und $X$.
@@ -1223,7 +1223,7 @@ Wir befinden uns zunächst im subkritischen Bereich, sprich unsere Analyse betra
     %\begin{enumerate}
     %\item
     Sei $p = (1 - \epsilon) / n$ und $k = (10 / \epsilon^2) \ln n$.
-    Dann gibt es mit hoher Wahrscheinlichkeit keine zusammenhängende Teilfolge (Intervall) mit Länge $nk$ (d.h. $X_i, \ldots, X_{i+nk}$) in dem mindestens $k$ Zufallsvariablen den Wert 1 haben.
+    Dann gibt es mit hoher Wahrscheinlichkeit keine zusammenhängende Teilfolge (Intervall) mit Länge $nk$ (\dh $X_i, \ldots, X_{i+nk}$) in dem mindestens $k$ Zufallsvariablen den Wert 1 haben.
 
     %\item Sei $p = (1 + \epsilon) /n$ und $N_0 = \epsilon n^2/2$.
     %      Dann gilt mit hoher Wahrscheinlichkeit $|\sum_{i=1}^{N_0} X_i - \epsilon(1+\epsilon)/2| \le n^{2/3}$.
@@ -1348,7 +1348,7 @@ Durch die Linearität des Erwartungswertes folgt dann die erwartete Anzahl an Cl
     \binom{|V|}{k} p^{k(k-1)/2}.
 \end{align}
 
-Wenn wir uns den Spezialfall von $\Gn$ (d.h. $\Gnp$ mit $p = 1/2$) ansehen, lässt sich zeigen, dass es eine Funktion $f(n) \approx 2\ln n$ gibt,
+Wenn wir uns den Spezialfall von $\Gn$ (\dh $\Gnp$ mit $p = 1/2$) ansehen, lässt sich zeigen, dass es eine Funktion $f(n) \approx 2\ln n$ gibt,
 sodass eine größte Clique in $G \sim \Gn$ mit hoher Wahrscheinlichkeit entweder $f(n)$ oder $f(n)+1$ Knoten hat.
 Diese können wir aufgrund der kleinen Größe relativ einfach finden!
 Wenn wir alle möglichen Cliquen explizit enumerieren und prüfen, ergibt sich \qq{nur} eine quasipolynomielle Laufzeit von $2^{\Theta(\log^2 n)}$.

--- a/grad_sequenzen.tex
+++ b/grad_sequenzen.tex
@@ -2,12 +2,12 @@ Während wir im vorherigen Kapitel Gradsequenzen als Stichproben einer Gradverte
 Konkret möchten wir für eine gegebene Gradsequenz~$\degseq$ einen Graphen~$G$ erzeugen, der folgende Eigenschaften erfüllt:
 \begin{enumerate}
     \item Graph~$G$ soll die Gradsequenz~$\degseq$ haben.
-    \item Graph~$G$ soll einfach sein (d.h., keine Mehrfachkanten oder Schleifen haben).
+    \item Graph~$G$ soll einfach sein (\dh, keine Mehrfachkanten oder Schleifen haben).
     \item Graph~$G$ soll eine uniforme Stichprobe aus allen passenden Graphen sein.
 \end{enumerate}
 
 Im Folgenden werden wir eine Reihe von Ansätzen untersuchen.
-Dabei wird sich zeigen, dass es einfach ist, wenn wir nur zwei Eigenschaften (d.h. 1\&2, 2\&3, oder 1\&3) erfüllen müssen.
+Dabei wird sich zeigen, dass es einfach ist, wenn wir nur zwei Eigenschaften (\dh 1\&2, 2\&3, oder 1\&3) erfüllen müssen.
 Für eine allgemeine Gradsequenz~$\degseq$ ist es hingegen schwer allen drei Anforderungen gerechnet zu werden.
 
 Bevor wir aber anfangen, sollten wir das \qq{Warum?} klären.
@@ -28,7 +28,7 @@ Es gibt zwei zentrale Motivationen Graphen mit allgemeinen Gradsequenzen erzeuge
           wir beobachteten Hub-Knoten, deren Grad wir nicht mit $\Gnp$ Graphen erklären konnten.
           Daraufhin schlugen wir das BA Modell vor.
 
-          Wenig überraschend haben das $\Gnp$ und das BA Modell deutliche Unterschiede (z.B. sind selbst sehr dünne BA Graphen zusammenhängend).
+          Wenig überraschend haben das $\Gnp$ und das BA Modell deutliche Unterschiede (\zB sind selbst sehr dünne BA Graphen zusammenhängend).
           Egal welches Modell wir wählen, es führt immer zu einer Verzerrung in der Bewertung unserer Beobachtungen.
 
           Daher kommen nicht selten uniform zufällige und einfache Graphen, die dieselbe Gradsequenz wie das beobachtete Netz ausweisen, zum Einsatz.
@@ -51,7 +51,7 @@ Prüfen wir kurz unser Lastenheft:
     \item \emph{Graph~$G$ soll die Gradsequenz~$\degseq$ haben}.
           Das stimmt: per Konstruktion ist jede Knoten~$i$ genau $d_i$ mal vertreten.
 
-    \item \emph{Graph~$G$ soll einfach sein (d.h., keine Mehrfachkanten oder Schleifen haben).}
+    \item \emph{Graph~$G$ soll einfach sein (\dh, keine Mehrfachkanten oder Schleifen haben).}
           Das können wir nicht versprechen: niemand stoppt uns ein Paar $i = j$ zu ziehen, wenn $d_i > 1$.
           Analog kann es auch passieren, dass wir dasselbe Paar mehrfach ziehen.
 
@@ -128,7 +128,7 @@ Wir treffen daher folgende Definitionen:
 
 \begin{definition}
     Sei $\degseq$ eine Gradsequenz.
-    Wir nennen $\degseq$ genau dann \emph{graphisch}, wenn $\gd \neq \emptyset$ (d.h., wenn es mindestens einen einfachen Graphen gibt, der $\degseq$ erfüllt).
+    Wir nennen $\degseq$ genau dann \emph{graphisch}, wenn $\gd \neq \emptyset$ (\dh, wenn es mindestens einen einfachen Graphen gibt, der $\degseq$ erfüllt).
 \end{definition}
 
 \noindent
@@ -158,7 +158,7 @@ In diesem Setting analysieren wir für große Knotenanzahl~$n$ die erwartete Anz
 
 \begin{exercise}
     Seien $G_1$ und $G_2$ zwei Graphen mit gleicher Knoten- und Kantenanzahl.
-    Beschreibe (qualitativ) zwei Gradverteilungen, s.d. wir für $G_1$ möglichst wenig kritische Kanten erwarten, während $G_2$ möglichst viele haben soll.
+    Beschreibe (qualitativ) zwei Gradverteilungen, \sd wir für $G_1$ möglichst wenig kritische Kanten erwarten, während $G_2$ möglichst viele haben soll.
     Erkläre (qualitativ), weshalb $\expv{M_n} \propto \expv{S_n^2}$ plausible wirkt.
 \end{exercise}
 
@@ -248,7 +248,7 @@ Während für Gradverteilungen mit $c_n = \Oh{1}$ das \emph{Erased Configuration
 Insbesondere skalenfrei Powerlaw Verteilungen sind notorisch schwierig.
 Dies liegt unter anderem daran, dass illegale Kanten häufiger auftreten und sich zudem um Hubs herum konzentrieren.
 Das \emph{Erased Configuration Model} hat daher einen Bias den Grad von Knoten mit vielen Nachbarn besonders stark abzusenken;
-dies wiederum hat signifikante Auswirkungen auf die Graphstruktur (siehe z.B. \cite{DBLP:journals/snam/SchlauchHZ15}).
+dies wiederum hat signifikante Auswirkungen auf die Graphstruktur (siehe \zB \cite{DBLP:journals/snam/SchlauchHZ15}).
 Wir werden später Techniken diskutieren, die illegale Kanten entfernen können, ohne dabei die Gradsequenz zu verändern.
 
 \subsection{Ans Gute glauben und das Schlechte ablehnen}
@@ -304,7 +304,7 @@ Als Extrembeispiel betrachten wir für großes $k \ggg 0$ die folgende Gradseque
     \right)
 \end{align}
 
-Hierbei handelt es sich um eine sog. Threshold Sequenz --- eine Gradsequenz bei denen alle einfache Graph isomorph sind (d.h. wenn wir die Knotenindizes löschen sind alle Graphen identisch).
+Hierbei handelt es sich um eine sog. Threshold Sequenz --- eine Gradsequenz bei denen alle einfache Graph isomorph sind (\dh wenn wir die Knotenindizes löschen sind alle Graphen identisch).
 Die hier beschriebene Sequenz erzeugt einen Graph mit einer Clique aus $k$ Knoten, wobei einer der Knoten~$u$ noch zu Knoten~$v$ verbunden ist.
 
 Das Problem besteht nun darin, dass das Blatt~$v$ genau zu Knoten~$u$ verbunden sein muss.
@@ -514,8 +514,8 @@ Wir können uns den Algorithmus wie folgt bildlich vorstellen, wobei die grauen 
 \subsubsection{Gewichtetes Ziehen ohne Zurücklegen: Rejection Sampling}
 Wir betrachten eine Verallgemeinerung des $\Gnp$ Samplings aus \cref{subsec:gnp_zufaellige_spruenge}.
 Anstelle eines gemeinsamen Akzeptanzparameters~$p$ wie bei Gilbert-Graphen, sei $w = (w_1, \ldots, w_n) \in [0, 1]^n$ ein Vektor, der jedem Element eine individuelle Wahrscheinlichkeit zuweist.
-Wir gehen weiter davon aus, dass $w$ absteigend sortiert ist, d.h. $w_i \ge w_{i+1}$ für alle $1 \le i < n$.
-Unser Ziel ist es eine Ausgabemenge $R \subseteq [n]$ zu generieren, s.d. $\prob{i \in R} = w_i$.
+Wir gehen weiter davon aus, dass $w$ absteigend sortiert ist, \dh $w_i \ge w_{i+1}$ für alle $1 \le i < n$.
+Unser Ziel ist es eine Ausgabemenge $R \subseteq [n]$ zu generieren, \sd $\prob{i \in R} = w_i$.
 Das Problem ist also \emph{gewichtetes Ziehen ohne Zurücklegen}.
 
 Ein naiver Ansatz iteriert einfach über alle $n$ Element und akzeptiert jedes Element mit Wahrscheinlichkeit $w_i$.
@@ -535,7 +535,7 @@ Konservativ müssen wir eine Wahrscheinlichkeit wählen, die mindestens so groß
 Hier trifft es sich gut, dass $w$ absteigend sortiert ist.
 Angenommen wir haben gerade Element~$i$ gewählt, dann führen wir einen geometrischen Sprung mit Erfolgswahrscheinlichkeit $w_{i+1}$ aus.
 Sei $j$ der Index den wir gezogen haben.
-Wenn $w_{i+1} = w_j$ gilt, hatten wir Glück, falls nicht haben wir $w_j$ überschätzt und müssen das korrigieren\ldots z.B. mit Rejection Sampling.
+Wenn $w_{i+1} = w_j$ gilt, hatten wir Glück, falls nicht haben wir $w_j$ überschätzt und müssen das korrigieren\ldots \zB mit Rejection Sampling.
 
 Element~$j$ wurde mit Wahrscheinlichkeit $w_{i+1}$ vorgeschlagen, es soll aber nur mit Wahrscheinlichkeit $w_j$ ausgegeben werden.
 Wir akzeptieren also mit Wahrscheinlichkeit $w_{j} / (s \cdot w_{i+1})$; als Skalierung wählten1 wir also implizit $s=1$ (warum?).
@@ -668,7 +668,7 @@ Wir übernehmen auch die Notation $a \div b = \lfloor a / b \rfloor$.
 \bigskip
 
 Auf praktischen Computern erhalten wir (Pseudo)Zufallszahlen in der Regel in der Größe eines Maschinenwortes, oft mit $L = 32$ oder $64$ Bit.
-Wir können dies entweder als $L$~unabhängige Zufallsbits interpretieren, oder z.B. als eine vorzeichenlose Ganzzahl~$X$, die uniform auf $[0, 2^L)$ verteilt ist.
+Wir können dies entweder als $L$~unabhängige Zufallsbits interpretieren, oder \zB als eine vorzeichenlose Ganzzahl~$X$, die uniform auf $[0, 2^L)$ verteilt ist.
 In Anwendungen benötigen wir jedoch häufig Zahlen aus einem Intervall $[a, b)$ und müssen daher $X$ transformieren.
 
 Den kleinsten Wert anzupassen ist einfach: wir ziehen aus $Y' \in [0, b-a)$ und geben $Y = a + Y'$ zurück.
@@ -712,7 +712,7 @@ Wenn $X$ uniform ist, ist es die Ausgabe dann auch.
 Allerdings ist für $s \ll 2^L$ die Verwerfungsrate exorbitant hoch;
 in Erwartung benötigen wir $2^L / s$ Versuche!
 
-Besser ist es natürlich ein möglichst großes $k \ge 1$ zu wählen, s.d. $k s \le 2^L$.
+Besser ist es natürlich ein möglichst großes $k \ge 1$ zu wählen, \sd $k s \le 2^L$.
 Dann verwerfen wir nur $X \ge ks$ und liefern sonst $X / k$ zurückzuliefern.
 Die beste Wahl ist $k = 2^L \div s$.
 Dieses Verfahren hat eine Akzeptanzwahrscheinlichkeit von
@@ -738,7 +738,7 @@ Das führt zu folgendem Schema, das auch als OpenBSD Algorithmus bekannt ist:
 Der OpenBSD Algorithmus ist einfach und korrekt, hat aber einen enormen Nachteil in der Praxis:
 Pro Aufruf muss ein Modulo und eine Division (das ist idR dieselbe CPU-Instruktion!) berechnet werden.
 Eine \texttt{div} Instruktion gehört zu den teuersten skalaren Operationen\footnote{Sehr umfangreiche Benchmarks und Infos: \url{https://www.agner.org/optimize/instruction_tables.pdf}}, die CPUs unterstützen.
-Im Vergleich zu einfacher Arithmetik (z.B. Addition) ist eine Division oft um ein bis zwei Größenordnungen langsamer.
+Im Vergleich zu einfacher Arithmetik (\zB Addition) ist eine Division oft um ein bis zwei Größenordnungen langsamer.
 Insb. erzeugen moderne nicht-kryptographischen Pseudozufallsgeneratoren eine Zufallszahl oft schneller als eine einzelne Division dauert!
 
 OpenJDK verwendet ein anderes Verfahren, das die Anzahl der Divisionen an die Anzahl der Runden des Rejection Samplings knüpft.
@@ -754,7 +754,7 @@ OpenJDK verwendet ein anderes Verfahren, das die Anzahl der Divisionen an die An
     \caption{Java Algorithmus zum Ziehen uniformer Ganzzahlen.}
 \end{algorithm}
 
-Wir müssen genau dann verwerfen, wenn $ks \le x \le (k+1)s$ mit $(k+1)s > 2^L$, d.h. wenn $x$ aus einem \qq{$s$-Intervall} stammt, das nicht vollständig in $[0, 2^L)$ enthalten ist.
+Wir müssen genau dann verwerfen, wenn $ks \le x \le (k+1)s$ mit $(k+1)s > 2^L$, \dh wenn $x$ aus einem \qq{$s$-Intervall} stammt, das nicht vollständig in $[0, 2^L)$ enthalten ist.
 Beobachte, dass $x - r = x - (x \bmod s) = (x \div s)s$ dem größten Vielfachen von $s$ entspricht, das $x$ nicht übersteigt;
 es ist also die linke Intervallgrenze.
 Die rechte Intervallgrenze ergibt sich dann als $x- r +s$.
@@ -845,7 +845,7 @@ Um die Datenstruktur speicher-effizient zu gestalten, konstruieren wir eine Tabe
 Statt die Verteilung auf $1$ oder $k$ zu normieren, verwenden wir direkt die Anzahl an Kugeln pro Farbe.
 Das hat zum Einen den Vorteil, dass wir mit reiner Ganzzahlarithmetik arbeiten können, zum Anderen aber auch nicht renormieren müssen, wenn Kugeln hinzugefügt oder entnommen werden.
 
-Aus unserer Diskussion des letzten Kapitels wissen wir aber bereits, dass es im Allgemeinen nicht möglich sein kann, $n$ Kugeln auf $k$ Zeilen zu verteilen, s.d. alle Zeilen identisches Gewicht haben.
+Aus unserer Diskussion des letzten Kapitels wissen wir aber bereits, dass es im Allgemeinen nicht möglich sein kann, $n$ Kugeln auf $k$ Zeilen zu verteilen, \sd alle Zeilen identisches Gewicht haben.
 Sei $T[i]$ das Gewicht der $i$-ten Zeile.
 Falls $n \bmod k \ne 0$, gibt es mindestens zwei Zeilen $i$ und $j$ mit  $T[i] = \lfloor n / k \rfloor\ \ne\ \rfloor n / k = T[j]$.
 mit Rejection-Sampling können wir aber die leichte Verzerrung einfach korrigieren.
@@ -916,7 +916,7 @@ Um die Beschreibung einfach zu halten, stellen wir eine Vereinfachung vor, die Z
 Mit ein paar Tricks können beide Schranken auf $\Oh{1}$ (worst-case) gedrückt werden.
 
 Hierbei \aside{iterierte Logarithmus $\underbrace{\log_2(\ldots \log_2}_\text{$k$ mal}(x)) \le 1$} ist $\lgs(n)$ der sog. \emph{iterierte Logarithmus}.
-Dieser ist definiert als das kleinste ganzzahlige $k$, s.d. $\log^{(k)}(n) \le 1$, wobei $\log^{(k)}(n)$ die $k$-fache Anwendung des Logarithmus ($\log_2(\log_2(\ldots \log_2(x)))$) beschreibt.
+Dieser ist definiert als das kleinste ganzzahlige $k$, \sd $\log^{(k)}(n) \le 1$, wobei $\log^{(k)}(n)$ die $k$-fache Anwendung des Logarithmus ($\log_2(\log_2(\ldots \log_2(x)))$) beschreibt.
 Es ist eine extrem langsam-wachsende Funktion $\lgs(10^{80}) = 4$, wobei $10^{80}$ etwa der Anzahl an Atome im Universum entspricht;
 $\lgs({2^{65536}})=5$, wobei $2^{65536}$ mehr als $20\,000$ Ziffern in Dezimalschreibweise hat.
 Für alle praktischen Anwendungen, in denen $n$ linear zu einer Ressource (etwa Speicher oder Laufzeit) korrespondiert, können wir $\lgs(n)$ daher als Konstante von höchstens $4$ annehmen.
@@ -964,7 +964,7 @@ Pro Leveltabelle speichern wir noch das Gesamtgewicht des Levels $\wght(T_j) = \
 
 Wir verwalten zudem ein Bitset, um die Wurzel in Level~$\ell$ zu markieren.
 Etwas \qq{hacky}, speichern wir dies als eine Binärzahl $X_\ell = \sum_{j \in T_\ell} 2^j$ in Festkommadarstellung, in der das $j$-te Bit genau dann gesetzt ist, wenn $j \in T_\ell$.
-Aufgrund unserer Annahmen bzgl. des Maschinenmodells können wir $X_\ell$ in einem Wort darstellen und in Konstantzeit z.B. das höchstwertige Bit finden.
+Aufgrund unserer Annahmen bzgl. des Maschinenmodells können wir $X_\ell$ in einem Wort darstellen und in Konstantzeit \zB das höchstwertige Bit finden.
 
 \subsubsection{Ziehen aus der Datenstruktur}
 Schließlich sei $L$ das größte Level in der Datenstruktur; wir werden zeigen, dass $L = \Oh{\lgs (n)}$ gilt.
@@ -973,12 +973,12 @@ Jetzt \aside{Sampling} können wir den Samplingalgorithmus beschreiben:
 \begin{enumerate}
     \item Ziehe ein $1 \le \ell \le L$ zufällig gewichtet nach $\wght(T_\ell)$.
           Da $L = \Oh{\lgs(n)}$, können wir das mittels linearer Suche implementieren:
-          Wir ziehen~$U$ uniform aus $[0, W)$ und suchen das kleinste $\ell$, s.d. $U < \sum_{1\le k \le \ell} \wght(T_k)$.
+          Wir ziehen~$U$ uniform aus $[0, W)$ und suchen das kleinste $\ell$, \sd $U < \sum_{1\le k \le \ell} \wght(T_k)$.
 
     \item Ziehe ein $j \in T_\ell$ zufällig gewichtet nach $\wrng{\ell}{j}$.
           Auch hier können wir eine lineare Suche anwenden:
-          Ziehe $U$ uniform aus $[0, \wght(T_j))$ und suche das kleinste $j$, s.d. $U \le \sum_{k \le j} \wrng{\ell}{k}$.
-          Zwar haben wir keine nützliche obere Schranke für die Anzahl der Wurzeln pro Level, jedoch können wir bei der schwersten Wurzel (d.h. dem höchstwertigsten gesetzten Bit in $X_\ell$) starten und dann $j$ iterativ dekrementieren.
+          Ziehe $U$ uniform aus $[0, \wght(T_j))$ und suche das kleinste $j$, \sd $U \le \sum_{k \le j} \wrng{\ell}{k}$.
+          Zwar haben wir keine nützliche obere Schranke für die Anzahl der Wurzeln pro Level, jedoch können wir bei der schwersten Wurzel (\dh dem höchstwertigsten gesetzten Bit in $X_\ell$) starten und dann $j$ iterativ dekrementieren.
           Da sich das größtmögliche verbleibende Gewicht jedes Mal grob halbiert, ergibt sich eine erwartet konstante Laufzeit (vgl. geometrisch Verteilung).
 
     \item Innerhalb von $\rng{\ell}{j}$ wählen wir nun ein Element gewichtet nach dessen Gewicht mittels Verwerfungsmethode.
@@ -990,7 +990,7 @@ Jetzt \aside{Sampling} können wir den Samplingalgorithmus beschreiben:
 \subsubsection{Erstellen und aktualisieren der Datenstruktur}
 Initial können wir die Datenstruktur in Zeit $\Oh{n}$ konstruieren.
 Dafür verarbeiten wir die $\Oh{n}$ Gewichte der Eingabe und fassen sie in Intervalle $\rng{1}{j}$ zusammen.
-Alle internen Intervall (d.h. solche mit mindestens zwei Elementen) sammeln wir zunächst in einer Queue.
+Alle internen Intervall (\dh solche mit mindestens zwei Elementen) sammeln wir zunächst in einer Queue.
 Diese verarbeiten wir rekursiv, nachdem das aktuelle Level fertiggestellt wurde.
 Die Verarbeitung eines Levels ist in Zeit linear in der Anzahl der Elemente des Levels möglich.
 Da die Datenstruktur insg. $\Theta(n)$ Knoten hat, folgt also eine Gesamtlaufzeit von $\Oh{n}$.
@@ -1001,7 +1001,7 @@ Wir beginnen in Level~$\ell=1$ und passen das entsprechende Gewicht an.
 Es gibt zwei Optionen:
 \begin{itemize}
     \item Die Änderungen ist ausreichend klein, so dass das Gewicht in seinem ursprünglichen Intervall~$\rng{1}{j}$ verbleibt.
-          Dann müssen wir das entsprechende Intervall anpassen (d.h. sein Gesamtgewicht und die Änderungen auch rekursiv in $\ell +1$ oder $T_\ell$ widerspiegeln).
+          Dann müssen wir das entsprechende Intervall anpassen (\dh sein Gesamtgewicht und die Änderungen auch rekursiv in $\ell +1$ oder $T_\ell$ widerspiegeln).
 
 
     \item Wenn das Element von $\rng{1}{j}$ in ein neues Intervall $\rng{1}{j'}$ wechselt, müssen wir die Änderungen für beide Intervalle propagieren.
@@ -1009,7 +1009,7 @@ Es gibt zwei Optionen:
 
 Pro Level kann sich also die Anzahl der betroffenen Intervalle im Worst-Case verdoppeln.
 Da es $L = \Oh{\lgs(n)}$ Level gibt, folgt eine worst-case Updatezeit von amortisiert $\Oh{2^{\lgs(n)}}$.
-Die Amortisierung findet dabei über die Hilfsdatenstrukturen (z.B. Hashtabellen) statt.
+Die Amortisierung findet dabei über die Hilfsdatenstrukturen (\zB Hashtabellen) statt.
 
 \subsubsection{Tiefe des Walds}
 Im Folgenden skizzieren wir die Beweisidee, um die Tiefe des Waldes zu beschränken.
@@ -1055,5 +1055,5 @@ Mit Hilfe dieser beiden Lemmata folgt, dass für ein $\ell \ge k \ge 3$ die Anza
 \begin{align}
     \left. 2^{2^{\rddots{2^m}}} \right\} \text{$k$ mal}
 \end{align}
-ist, d.h. $2^{2^m}$ für $k=3$ und $2^{2^{2^m}}$ für $k=4$.
+ist, \dh $2^{2^m}$ für $k=3$ und $2^{2^{2^m}}$ für $k=4$.
 Diese untere Schranke an die Anzahl der Nachfahren übersetzt sich dann wiederum in eine obere Schranke $\Oh{\lgs(n)}$ der Tiefe.

--- a/grad_sequenzen_hh.tex
+++ b/grad_sequenzen_hh.tex
@@ -6,7 +6,7 @@ Die Intuition von beiden Ansätzen ist aber ähnlich.
 
 \subsection{Erd\H{o}s-Gallai Theorem}
 \begin{theorem}
-    Sei $\degseq = (d_1, \ldots, d_n)$ eine nicht-wachsende Gradsequenz, d.h.
+    Sei $\degseq = (d_1, \ldots, d_n)$ eine nicht-wachsende Gradsequenz, \dh
     \begin{align}
         n > d_1 \ge d_2 \ge \ldots \ge d_n \ge 1.
     \end{align}
@@ -22,8 +22,8 @@ Die Intuition von beiden Ansätzen ist aber ähnlich.
     Analysiere dessen Laufzeit.
 \end{exercise}
 
-Im Folgenden diskutieren wir kurz, weshalb das Erd\H{o}s-Gallai Theorem eine notwendige Bedingung formuliert (d.h. jede graphisch Sequenz erfüllt das Theorem).
-Die Gegenrichtung (d.h. jede erfüllende Gradsequenz ist graphisch) ist deutlich komplexer und wird hier nicht behandelt.
+Im Folgenden diskutieren wir kurz, weshalb das Erd\H{o}s-Gallai Theorem eine notwendige Bedingung formuliert (\dh jede graphisch Sequenz erfüllt das Theorem).
+Die Gegenrichtung (\dh jede erfüllende Gradsequenz ist graphisch) ist deutlich komplexer und wird hier nicht behandelt.
 
 Die Anforderung, dass die Gradsumme gerade sein muss, folgt trivial aus dem Handshaking Lemma:
 jede Kante hat zwei Endpunkte und erhöht somit die Gradsumme um zwei
@@ -47,7 +47,7 @@ Daher fordert das Erd\H{o}s-Gallai Theorem $\Delta \le \sum_{i=k+1}^n \min(k, d_
 
 \subsection{Havel-Hakimi Theorem}
 \begin{theorem}
-    Sei $\degseq = (s, t_1, \ldots, t_s, d_{s+1}, \ldots, d_n)$ eine nicht-wachsende Gradsequenz auf $n$ Knoten, d.h.
+    Sei $\degseq = (s, t_1, \ldots, t_s, d_{s+1}, \ldots, d_n)$ eine nicht-wachsende Gradsequenz auf $n$ Knoten, \dh
     \begin{align}
         n > s \ge t_1 \ge \ldots t_s \ge d_{s+1} \ge \ldots \ge d_n \ge 1.
     \end{align}
@@ -71,10 +71,10 @@ Daher fordert das Erd\H{o}s-Gallai Theorem $\Delta \le \sum_{i=k+1}^n \min(k, d_
     Angenommen $\degseq = (s, t_1, \ldots, t_s, d_{s+1}, \ldots, d_n)$ ist graphisch, dann existiert ein einfacher Graph~$G$, dessen Knoten wir $S, T_1, \ldots, T_s, D_{s+1}, \ldots, D_n$ (anhand des offensichtlichen Mappings) nennen.
     Wenn $S$ zu $T_1, \ldots T_s$ verbunden ist, sind wir fast fertig: wir entfernen $S$ und alle inzidenten Kanten und erhalten den Graphen $G'$, der $\degseq'$ erfüllt.
 
-    Im Allgemeinen ist dies aber nicht richtig, d.h. es existiert ein $T_i$ das \emph{nicht} adjazent zu $S$ ist.
+    Im Allgemeinen ist dies aber nicht richtig, \dh es existiert ein $T_i$ das \emph{nicht} adjazent zu $S$ ist.
     Wir konstruieren nun aus $G$ einen einfachen Graphen $G_i$, in dem die Kante $\set{S, T_i}$ existiert ohne zuvor ggf. existierenden Kanten $\set{S, T_j}$ zu verändern.
 
-    Fixiere also ein $i$, s.d. die Kante $(S, T_i)$ nicht existiert, und ein $j$, s.d. die Kante $\set{S, D_j}$ existiert.
+    Fixiere also ein $i$, \sd die Kante $(S, T_i)$ nicht existiert, und ein $j$, \sd die Kante $\set{S, D_j}$ existiert.
     Aufgrund der Sortierung von~$\degseq$ gilt $t_i \ge d_j$:
     \begin{figure}
         \begin{center}
@@ -142,7 +142,7 @@ Bis diese leer ist, führen wir die folgende Schritte aus:
     \item Für alle $i$, falls $t_i > 1$ füge Knoten $T_i$ mit Gewicht~$t_1 - 1$ erneut ein
 \end{itemize}
 
-Mit klassischen PQs (z.B. Max-Heap) lässt sich hierdurch eine Laufzeit von $\Oh{(m + n) \log n}$ erzielen;
+Mit klassischen PQs (\zB Max-Heap) lässt sich hierdurch eine Laufzeit von $\Oh{(m + n) \log n}$ erzielen;
 unter der Annahme, dass die Eingabe Knoten von Grad~0 erhält vereinfacht sich der Term zu $\Oh{m \log n}$.
 
 Da die Schlüssel in der PQ jedoch ganzzahlig sind und aus dem Intervall $[1, n)$ stammen, können wir eine Bucket-Queue verwenden.

--- a/grad_verteilung.tex
+++ b/grad_verteilung.tex
@@ -10,7 +10,7 @@ Daher wollen wir die Verteilung von Graden in Graphen in diesem Kapitel genauer 
 Zur Wiederholung:
 In einem ungerichteten Graphen~$G=(V,E)$ beschreibt
 \begin{align}
-    \deg(u) = \card{\twoset{e}{e \in E\text{, s.d. } u \in e}}
+    \deg(u) = \card{\twoset{e}{e \in E\text{, \sd\,} u \in e}}
 \end{align}
 die Anzahl der Nachbarn von Knoten~$u$.
 Die \aside{Grad\underline{sequenz}} Gradsequenz~$\degseq_G$ (falls $G$ klar ist auch nur $\degseq$) von $G=(V,E)$ mit $V=\set{v_1, \ldots, v_n}$ ist dann einfach die Auflistung aller Grade im Graphen
@@ -58,7 +58,7 @@ Der Grad~$\deg(u)$ eines Knotens~$u$ ist also ebenfalls binomial verteilt:
 Daher gilt also $\expv{\deg(u)} = (n-1)p$.
 
 Wie in \cref{fig:histogram_grade_gnp} dargestellt, approximiert eine konkrete Gradsequenz~$\degseq_G$ die Gradverteilung schon sehr gut.
-Der Erwartungswert sollte daher gegen den Durchschnittsgrad $\bar d = 2m / n$ konvergieren, d.h. $\expv{\deg(u)} \approx \bar d$.
+Der Erwartungswert sollte daher gegen den Durchschnittsgrad $\bar d = 2m / n$ konvergieren, \dh $\expv{\deg(u)} \approx \bar d$.
 Dann gilt also:
 \begin{align}
     \bar d \approx \expv{\deg(u)} & = (n-1)p \\
@@ -293,13 +293,13 @@ Es muss also gelten, dass $\prob{\deg(u) \ge \dnc} = 1 / n$ ist:
 
 Für $\gamma  < 2$ sagt diese Gleichung einen Knoten voraus, der mehr Nachbarn hat, als es Knoten im Graphen gibt.
 Dies ist nur eines von vielen Indizien, die zu unserer Annahme $\gamma > 2$ führen.
-Für $\gamma \searrow 2$ (d.h. rechts-seitiger Grenzwert für $\gamma \to 2$) skaliert der maximale Grad als $\Theta(n)$.
+Für $\gamma \searrow 2$ (\dh rechts-seitiger Grenzwert für $\gamma \to 2$) skaliert der maximale Grad als $\Theta(n)$.
 Für $\gamma = 3$ ist er noch $\Theta(\sqrt{n})$ et cetera.
 
 \section{Wie entstehen eine Power Law Gradverteilungen?}
 Das Entstehen von Power Law Verteilungen in  unterschiedlichsten Netzwerken gibt Anlass zu der Frage, wie solche Verteilungen denn eigentlich entstehen.
 Barab{\'{a}}si und Albert~\cite{barabasi1999emergence} geben eine sehr populäre Erklärung, die besonders durch ihre Simplizität besticht.
-Ähnliche Techniken wurden jedoch bereits früher verfolgt (z.B.~\cite{10.2307/1716232}).
+Ähnliche Techniken wurden jedoch bereits früher verfolgt (\zB~\cite{10.2307/1716232}).
 
 Die beiden Autoren schlagen neues Modell vor, das wir im Folgenden BA-Modell nennen.
 Es stellt zwei implizite Annahmen von \Gnp und \Gnm Graphen infrage:
@@ -311,7 +311,7 @@ Es stellt zwei implizite Annahmen von \Gnp und \Gnm Graphen infrage:
 
     \item
           Wenn wir einen Knoten im \Gnp Graphen als Spieler interpretieren, nimmt das Modell an, dass die Nachbarn rein zufällig ausgesucht werden.
-          Tatsächlich unterliegen aber viele Handlungen im echten Leben einem sog. Bias (d.h. einer verzerrten Wahrscheinlichkeitsverteilung).
+          Tatsächlich unterliegen aber viele Handlungen im echten Leben einem sog. Bias (\dh einer verzerrten Wahrscheinlichkeitsverteilung).
 
           Dies ist besonders auffällig, wenn es zu einer Form von Selektion kommt.
           So kann kein Mensch alle Webseiten kennen (und dann darauf verlinken); von Facebook, Twitter, und Google haben die Meisten aber gehört.
@@ -348,7 +348,7 @@ Der beschriebene Bias wird \emph{Preferential Attachment} bezeichnet.
 Es bildet sich eine positive Rückkopplung:
 ein Knoten mit hohem Grad wird wahrscheinlicher als andere Knoten gezogen.
 Ein gut vernetzter Knoten akkumuliert also schneller neue Nachbarn, und wird dadurch noch berühmter.
-Der Prozess liegt daher einigen Sprichworten zugrunde, z.B. \qq{the rich get richer} (dt. \qq{Der Teufel ... auf den größten Haufen}).
+Der Prozess liegt daher einigen Sprichworten zugrunde, \zB \qq{the rich get richer} (dt. \qq{Der Teufel ... auf den größten Haufen}).
 Es gibt diverse Methoden zur formalen Analyse des Prozess --- eine der einfachsten ist der kontinuierliche Formalismus, in der wir Knotengrade und die Zeit durch reelle Zahlen approximieren.
 Der Einfachheit halber, verwenden wir dennoch weiterhin den Begriff Zeitschritt, womit wir ein Zeitintervall von Einheitslänge meinen.
 
@@ -412,7 +412,7 @@ Wir müssen dieses Ergebnis noch in eine Gradverteilung zum Zeitpunkt $T \ggg 1$
 Die Intuition hierfür ist folgende:
 Wir wissen, dass wir zum Zeitpunkt~$T$ insgesamt $T$ zufällige Knoten hinzugefügt haben und können annehmen, dass wir das in einem regelmäßigen Takt getan haben.
 Dann müssen wir nur noch extrapolieren, welchen Grad wir für jeden diesen Knoten zu Zeitpunkt $T$ erwarten.
-Konkret fragen wir uns, wann ein Knoten eingefügt werden musste, s.d. er höchsten Grad $k$ hat:
+Konkret fragen wir uns, wann ein Knoten eingefügt werden musste, \sd er höchsten Grad $k$ hat:
 \begin{align}
                     &  & d(T)                                   & < k         \\
     \Leftrightarrow &  & \nu \left(\frac{T}{t_i}\right)^\beta   & < k         \\
@@ -481,7 +481,7 @@ Der vollständige Generator ist in \cref{alg:bb_ba} zusammengefasst.
 Der Generator \cref{alg:bb_ba} hat jedoch eine praktische Schwäche:
 die $\nu$ Nachbarn eines Knotens werden unabhängig gezogen --- es kann also zu Mehrfachkanten kommen.
 Dies ist in viele Anwendungen unerwünscht.
-Daher gehen wir im Folgenden davon aus, dass der Startgraph einfach ist (d.h., keine Mehrfachkanten enthält).
+Daher gehen wir im Folgenden davon aus, dass der Startgraph einfach ist (\dh, keine Mehrfachkanten enthält).
 
 Dann können wir Mehrfachkanten recht einfach erkennen:
 wir müssen nur die $\nu$ anfänglichen Nachbarn eines jeden neuen Knoten auf Duplikate prüfen.
@@ -515,7 +515,7 @@ Vereinfachend betrachten wir nur $\nu = 1$; die Ideen lassen sich aber auch auf 
 
 \subsubsection{Abhängigkeiten vermeiden}
 Das Generieren von BA Graphen wurde bis vor wenigen Jahren noch als \emph{inhärent sequentielles} Problem bezeichnet.
-Jeder gezogene Knoten verändert die Gradverteilung, s.d. sich zwischen den neu eingefügten Kanten Abhängigkeiten ergeben.
+Jeder gezogene Knoten verändert die Gradverteilung, \sd sich zwischen den neu eingefügten Kanten Abhängigkeiten ergeben.
 Allerdings gibt uns \cref{alg:bb_ba} bereits ein mentales Bild an die Hand, mit dem wir diese Abhängigkeiten in den Griff bekommen können.
 Um die Beschreibung zu vereinfachen, gehen wir davon aus, dass jeder Eintrag im Array einer Kante entspricht (statt eigentlich zwei Einträgen pro Kante).
 Dies ist eine asymptotisch nicht relevante Abschätzung zu unseren Ungunsten (siehe auch \cref{subsec:ba_sanders}).
@@ -616,7 +616,7 @@ Da jede Epoche in Erwartung eine Laufzeit von $\Oh{1}$ hat, hängt also die Lauf
 
     Dieses Vorgehen wiederholen wir logarithmisch oft.
     Vorsicht ist aber geboten, da wir um von $2e_1 \to 2(2e_1)$ zu kommen $\sqrt{2 e_1}$ (statt wie vorher nur $\sqrt{e_1}$) Epochen benötigen.
-    Sei $k$ die Anzahl an notwendigen Epochen, d.h. $e_k \ge m$.
+    Sei $k$ die Anzahl an notwendigen Epochen, \dh $e_k \ge m$.
     Es folgt:
 
     \begin{align}
@@ -717,7 +717,7 @@ Damit wird auf die Selbstähnlichkeit der Power-Law Verteilung hingewiesen:
 eine perfekte Power Law Verteilung ist in einem Log-Log-Plot immer eine Grade mit Steigung $-\gamma$.
 Dabei ist unerheblich wie groß der zugrunde liegende Objekt (hier Knotenmenge) ist.
 
-Wir können also die Verteilung umskalieren, z.B. die Knotenanzahl um einen Faktor $a$ vergrößern.
+Wir können also die Verteilung umskalieren, \zB die Knotenanzahl um einen Faktor $a$ vergrößern.
 Dann gilt für die entsprechende Zufallsvariablen $X$ und $X'$:
 
 \begin{align}

--- a/graph_randomisierung.tex
+++ b/graph_randomisierung.tex
@@ -1,5 +1,5 @@
 Mit dem Havel-Hakimi Generator können wir nun für jede graphische Sequenz einen Graphen als Zeugen für diese Sequenz erzeugen.
-Die generierten Graphen sind aber zum einen deterministisch, d.h. für eine fixierte Sequenz~$\degseq$ wird immer derselbe Graph erzeugt, und zum anderen pathologisch (extrem viele Dreiecke, extrem hohe Grad Assortitivät, \ldots).
+Die generierten Graphen sind aber zum einen deterministisch, \dh für eine fixierte Sequenz~$\degseq$ wird immer derselbe Graph erzeugt, und zum anderen pathologisch (extrem viele Dreiecke, extrem hohe Grad Assortitivät, \ldots).
 Das Fixed-Degree-Sequence-Model (FDSM)\aside{ Fixed-Degree-Sequence-Model (FDSM)} schlägt daher vor, dass wir erst den Havel-Hakimi Algorithmus ausführen, und dann den Graphen durch viele zufällige kleine Änderungen lokal perturbieren.
 Es besteht die begründete Hoffnung, dass wenn der hierdurch implizierte Irrweg lang genug ist, dass wir dann schlussendlich einen (fast) uniformen Graph aus $\Gd$ produzieren.
 
@@ -13,13 +13,13 @@ Edge Switching ist wohl der meist genutzte Prozess zum Perturbieren von Graphen.
 Das ist sicherlich auch dem geschuldet, dass er sehr einfach zu implementieren ist und in der Praxis relativ gut funktioniert (mehr dazu später).
 
 Anders als bei den meisten Modellen, gibt es signifikante funktionale Unterschiede zwischen gerichteten und ungerichteten Graphen.
-Edge Switching funktioniert aber mit noch ausgefalleneren Graphklassen (siehe z.B. \cite{carstens_2017}), z.B.
+Edge Switching funktioniert aber mit noch ausgefalleneren Graphklassen (siehe \zB \cite{carstens_2017}), \zB
 \begin{itemize}
     \item Ungerichtete einfache Graphen mit fester Gradsequenz
     \item Ungerichtete einfache zusammenhängende Graphen  mit fester Gradsequenz \cite{DBLP:journals/compnet/VigerL16}
     \item Gerichtete Graphen  mit fester Gradsequenz
     \item Gerichtete einfache Graphen (mit einfacher Modifikation)  mit fester Gradsequenz
-    \item Graphen mit fester joint-degree sequence~\cite{DBLP:conf/alenex/StantonP11} (d.h. die Anzahl der Kanten zwischen Knoten mit Graden~$d_1$ bzw.~$d_2$ wird für alle Paare $(d_1, d_2)$ definiert)
+    \item Graphen mit fester joint-degree sequence~\cite{DBLP:conf/alenex/StantonP11} (\dh die Anzahl der Kanten zwischen Knoten mit Graden~$d_1$ bzw.~$d_2$ wird für alle Paare $(d_1, d_2)$ definiert)
     \item Bipartite Graphen
     \item Mit weiteren Modifikationen sind auch weitere Klassen möglich
 \end{itemize}
@@ -63,7 +63,7 @@ Dies motiviert folgende Abstraktion:
 
 Seien $Z=(z_1, \ldots, z_n)$ und $S=(s_1, \ldots, s_m)$ Zeilen- und Spaltensummen.
 Dann \aside{\msz: Binärmatrizen mit fixierten Zeilen- und Spaltensummen} sei \msz die Menge aller $\set{0, 1}^{n \times m}$ Matrizen, die diese Beschränkungen erfüllen.
-Konkrete Graphklassen stellen i.d.R. weitere Anforderungen; so müssen ungerichtete einfache Graphen noch erfüllen:
+Konkrete Graphklassen stellen \idR weitere Anforderungen; so müssen ungerichtete einfache Graphen noch erfüllen:
 \begin{itemize}
     \item $Z = S$
     \item Matrizen sind symmetrisch
@@ -87,12 +87,12 @@ jeweils gegenüberliegende Ecken haben also dieselben Werte in der $M$ und deren
 
 \begin{theorem}
     OBdA sei $(a_{ij})_{ij} = A \ne B = (b_{ij})_{ij}$ (da wir sonst fertig sind).
-    Dann sei $d$ die Hamming-Distanz zwischen $A$ und $B$, d.h. die Anzahl der Einträge, in denen sich beide unterscheiden.
+    Dann sei $d$ die Hamming-Distanz zwischen $A$ und $B$, \dh die Anzahl der Einträge, in denen sich beide unterscheiden.
     Beobachte, dass $d$ eine gerade positive Zahl sein muss (weshalb?).
 
     Dann existiert ein Index $(i_1, j_1)$ mit $a_{i_1j_1} \ne b_{i_1j_1}$ und sei oBdA $a_{i_1j_1} = 1$.
-    Da die Summe der $j_1$-ten Spalte fixiert ist, muss es in dieser eine Zeile $i_2$ geben, s.d. $a_{i_2j_1} = 0$ und $b_{i_2j_1} = 1$.
-    Da wiederum die Summe der $i_2$-ten Zeile fixiert ist, muss es ein $j_2$ geben, s.d. $a_{i_2j_2} = 1$ und $b_{i_2j_2} = 0$.
+    Da die Summe der $j_1$-ten Spalte fixiert ist, muss es in dieser eine Zeile $i_2$ geben, \sd $a_{i_2j_1} = 0$ und $b_{i_2j_1} = 1$.
+    Da wiederum die Summe der $i_2$-ten Zeile fixiert ist, muss es ein $j_2$ geben, \sd $a_{i_2j_2} = 1$ und $b_{i_2j_2} = 0$.
     Wir haben also drei Ecken gefunden.
 
     Könnten wir $a_{i_1j_2} = 0$ garantieren, hätten wir ein alternierendes Rechteck und wären fertig;
@@ -113,14 +113,14 @@ jeweils gegenüberliegende Ecken haben also dieselben Werte in der $M$ und deren
     Weiter wissen sogar, dass $A$ und $B$ mittels höchstens $d/2$ Switches in einander überführt werden können.
     Aufgrund der Symmetrie,
     \begin{align}
-        d/2 & = \card{\set{ (i, j) \middle| i, j \text{, s.d. } a_{ij} = 1 \land b_{ij} = 0}}  \\
-            & = \card{\set{ (i, j) \middle| i, j \text{, s.d. } a_{ij} = 0 \land b_{ij} = 1}},
+        d/2 & = \card{\set{ (i, j) \middle| i, j \text{, \sd\,} a_{ij} = 1 \land b_{ij} = 0}}  \\
+            & = \card{\set{ (i, j) \middle| i, j \text{, \sd\,} a_{ij} = 0 \land b_{ij} = 1}},
     \end{align}
     folgt direkt
     \begin{align}
         d/2 \le t =  \min\Big(
-         & \card{\set{ (i, j) \middle| i, j \text{, s.d. } a_{ij} = 1}},       \\
-         & \card{\set{ (i, j) \middle| i, j \text{, s.d. } a_{ij} = 0}}  \Big)
+         & \card{\set{ (i, j) \middle| i, j \text{, \sd\,} a_{ij} = 1}},       \\
+         & \card{\set{ (i, j) \middle| i, j \text{, \sd\,} a_{ij} = 0}}  \Big)
     \end{align}
 \end{theorem}
 
@@ -151,7 +151,7 @@ der Prozess hat also eine uniforme Grenzverteilung.
 Da wir in der Praxis jedoch immer nur endlich lange Irrwege ausführen können, wird der Edge Switching MCMC Algorithmus oft als \emph{approximativ uniform} bezeichnet.
 
 Zunächst wiederholen wir ein paar Definition aus den Anfangstagen des Informatikstudiums.
-Hierfür stellen wir eine Markov-Kette~$\mathcal M$ oft als Tupel $(G, P)$ mit gerichteten Graph $G = (V, E)$ dar, wobei $P$ ein stochastische $|V| \times |V|$-Matrix ist (d.h. jede Zeile summiert auf $1$) und $(i, j) \in E \Leftrightarrow P_{ij} > 0$.
+Hierfür stellen wir eine Markov-Kette~$\mathcal M$ oft als Tupel $(G, P)$ mit gerichteten Graph $G = (V, E)$ dar, wobei $P$ ein stochastische $|V| \times |V|$-Matrix ist (\dh jede Zeile summiert auf $1$) und $(i, j) \in E \Leftrightarrow P_{ij} > 0$.
 Gegeben eine Startverteilung $\pi \in [0, 1]^n$ (Zeilenvektor) entspricht das Vektormatrixprodukt $\pi P$ der Verteilung nach einem Schritt und $\pi P^k$ der Verteilung nach $k$ Schritten.
 
 \begin{definition}
@@ -224,7 +224,7 @@ Analoges gilt auch für ungerichtete Switches.
 \section{Implementieren von Edge Switching}
 Die sequentielle Implementierungen von Edge Switching für gerichtete und ungerichtete Graphen ist relativ ähnlich.
 Daher nehmen wir im Folgenden gerichtete Graphen an --- für einen ungerichteten Graphen müssen wir nur beachten, dass $\set{u, v} = \set{v, u}$ ist und beide Kanten\qq{richtungen} diesselbe Kante repräsentieren.
-Üblicherweise repräsentieren wir beide Richtung durch eine kanonische Repräsentation $(u, v)$, wobei wir z.B. durch $u \le v$ Uneindeutigkeiten verhindern.
+Üblicherweise repräsentieren wir beide Richtung durch eine kanonische Repräsentation $(u, v)$, wobei wir \zB durch $u \le v$ Uneindeutigkeiten verhindern.
 Vor jedem Zugriff auf die im Folgenden beschriebenen Datenstrukturen würden also prüfen, ob die Invariante gilt, und anderenfalls die Kantenrichtung flippen.
 
 Ein zufälliger Edge Switch benötigt die folgenden Operationen:
@@ -240,7 +240,7 @@ Die beiden letzten Operationen können auch in eine zusammengefasst werden.
 \subsection{Auf Adjazenzmatrizen}
 Adjazenzmatrizen können alle Operationen außer das Ziehen einer zufälligen Kante in konstanter Zeit ausführen.
 Das Ziehen von zufälligen Kanten können wir aber mit einer dedizierten Datenstruktur lösen ---
-z.B. ein ungeordnetes Array~$A$ in dem jede Kante genau einmal gespeichert wird.
+\zB ein ungeordnetes Array~$A$ in dem jede Kante genau einmal gespeichert wird.
 Bei der Implementierungen müssen wir uns aber bei Updates minimal geschickt anstellen.
 Für ein Update der Kante $(u,v)$ benötigen wir den entsprechenden Index~$i$ in $A$ mit $A[i] = (u,v)$;
 diesen müssen wir glücklicherweise nicht suchen, da wir ausnutzen können, dass wir nur Kanten ersetzen, die wir vorher gezogen haben.
@@ -251,7 +251,7 @@ Mit diesen wenigen Tricks können wir jeden Edge Switch in konstanter Zeit ausf�
 \subsection{Auf Adjazenzlisten}
 Adjazenzlisten sind in vielerlei Hinsicht eine Herausforderung für Edge Switching.
 Allerdings verwalten viele existierenden Softwarebibliotheken Graphen in Adjazenzlisten; daher kann es lohnenswert sein, direkt auf der nativen Graphrepräsentation zu arbeiten.
-Dies gilt vor allem dann, wenn wir während jedes Switch zusätzliche Eigenschaften prüfen wollen und z.B. eine Breitensuchen ausführen möchten, um den Zusammenhang des Graphs zu prüfen.
+Dies gilt vor allem dann, wenn wir während jedes Switch zusätzliche Eigenschaften prüfen wollen und \zB eine Breitensuchen ausführen möchten, um den Zusammenhang des Graphs zu prüfen.
 
 Um in einer Adjazenzlist eine Kante uniform zufällig zu ziehen, bietet sich ein zweistufiges Experiment an.
 Zunächst wählen wir einen Knoten~$u$ mit Wahrscheinlichkeit $\deg(u) / (2m)$ und dann einen von $u$ Nachbarn uniform zufällig.
@@ -260,7 +260,7 @@ Da Edge Switching den Grad von Knoten nicht verändert, ist es sinnvoll vorab in
 Um schnelle Updates zu unterstützen, ist es in der Regel hilfreich eine unsortierte Adjazenzlist vorzuhalten.
 Dann kosten aber Existenzanfragen für die Kante $\set{u,v}$ Laufzeit $\Oh{\min(\deg(u), \deg(v))}$.
 Alternativ könnten wir die Nachbarschaften sortiert halten, dann dauern aber Updates $\Oh{\deg(u) + \deg(v)}$ Zeit.
-Gerade bei verzerrten Gradverteiltungen (z.B. Power-Law) bietet sich daher die erste Variante an.
+Gerade bei verzerrten Gradverteiltungen (\zB Power-Law) bietet sich daher die erste Variante an.
 
 Es gibt aber noch einen weiteren Ansatz: so nutzt die Implementierung von~\cite{DBLP:journals/compnet/VigerL16} eine Adjazenzliste, bei denen hinreichend große Nachbarschaften als HashSets ausgelegt sind.
 In diesem Setting können wir einen Edge Switch mit einer erwartet konstanten Laufzeit ausführen.


### PR DESCRIPTION
Macros für deutsche Abkürzungen, damit Herr W. nicht dauernd \\, überall einfügen muss
- Macros für z.B., d.h., i.d.R., o.Ä., s.d., o.B.d.A. sowohl klein als auch groß geschrieben
- ACHTUNG: o.Ä. hat als Makro oA bekommen
- Vorkommnisse im Skript so gut es geht ersetzt (ich hoffe, mir ist nichts entgangen)

Hoffe ich kam dir jetzt nicht knapp zuvor (https://github.com/manpen/netsci/pull/9#issuecomment-1574947755)